### PR TITLE
support service broker catalog auto-configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,7 @@ Maven example:
 
 The framework requires the broker to just provide an implementation of a [`ProcessorChain` bean](cf-ops-automation-broker-framework/src/main/java/com/orange/oss/cloudfoundry/broker/opsautomation/ondemandbroker/processors/ProcessorChain.java).
 
-    @ComponentScan
-    @EnableAutoConfiguration
+    @SpringBootApplication
     public class Application {
     
         public static void main(String[] args) {
@@ -50,5 +49,69 @@ The framework requires the broker to just provide an implementation of a [`Proce
             return chain;
         }
     }
+
+## Configuring the service broker catalog
+
+The framework requires the broker to just provide an implementation of a [`Catalog` bean](https://github.com/spring-cloud/spring-cloud-cloudfoundry-service-broker/blob/master/src/main/java/org/springframework/cloud/servicebroker/model/Catalog.java).
+
+### Using @Configuration and @Bean to inject a Catalog bean
+
+There is an example of this approach in the [sample broker](cf-ops-automation-sample-broker/src/main/java/com/orange/oss/cloudfoundry/broker/opsautomation/ondemandbroker/sample/BrokerCatalogConfig.java).
+
+    @Configuration
+    public class BrokerCatalogConfig {
+    	@Bean
+    	public Catalog catalog() {
+    		return new Catalog(Collections.singletonList(
+    				new ServiceDefinition(
+    						"ondemand-service",
+    						"ondemand",
+    						"A simple ondemand service broker implementation",
+    						true,
+    						false,
+    						Collections.singletonList(
+    								new Plan("ondemand-plan",
+    										"default",
+    										"This is a default ondemand plan.  All services are created equally.",
+    										getPlanMetadata())),
+    						Arrays.asList("ondemand", "document"),
+    						getServiceDefinitionMetadata(),
+    						null,
+    						null)));
+    	}
+    }
+
+### Using spring-boot-starter-servicebroker-catalog to configure your service broker catalog
+
+[spring-boot-starter-servicebroker-catalog](spring-boot-starter-servicebroker-catalog) provides an opinionated spring boot 'starter' to simplify your catalog configuration.
+
+To benefit from the starter , add it to your POM:
+
+        <dependency>
+            <groupId>com.orange.oss.cloudfoundry.broker.opsautomation</groupId>
+            <artifactId>spring-boot-starter-servicebroker-catalog</artifactId>
+            <version>last_version</version>
+        </dependency>
+        
+You can then configure the [`Catalog`](https://github.com/spring-cloud/spring-cloud-cloudfoundry-service-broker/blob/master/src/main/java/org/springframework/cloud/servicebroker/model/Catalog.java)
+using properties files, YAML files, environment variables or command-line arguments.
+There is an example of this approach in the [sample broker](cf-ops-automation-sample-broker/src/main/resources/application.yml).
+
+Please, notice that you can also use `CATALOG_YML` environment variable to set catalog config in a YAML format.
+
+```shell
+#export catalog.yml file content as an env variable
+export CATALOG_YML="$(cat catalog.yml)"
+
+```
+
+See [catalog.yml](cf-ops-automation-sample-broker/catalog.yml) for details.
+
+
+
+
  
-For catalog management, the framework provides a default implementation that requires the broker to just provide an implementation of a [`Catalog` bean](https://github.com/spring-cloud/spring-cloud-cloudfoundry-service-broker/blob/master/src/main/java/org/springframework/cloud/servicebroker/model/Catalog.java). There is an example of this approach in the [sample broker](cf-ops-automation-sample-broker/src/main/java/com/orange/oss/cloudfoundry/broker/opsautomation/ondemandbroker/sample/BrokerCatalogConfig.java).
+
+
+
+

--- a/cf-ops-automation-sample-broker/catalog.yml
+++ b/cf-ops-automation-sample-broker/catalog.yml
@@ -1,0 +1,23 @@
+servicebroker:
+  catalog:
+    services:
+    - id: ondemand-service # mandatory field
+      name: ondemand # mandatory field
+      description: try a simple ondemand service broker implementation # mandatory field
+      bindable: true # defaults to true
+      plans:
+        - id: ondemand-plan # mandatory field
+          name: default # mandatory field; defaults to default
+          description: This is a default ondemand plan.  All services are created equally. # mandatory field
+      tags:
+        -ondemand
+        -document
+      metadata:
+        displayName: ondemand
+        imageUrl: https://orange.com/image.png
+        longDescription: ondemand Service
+        providerDisplayName: Orange
+        documentationUrl: https://orange.com/doc
+        supportUrl: https://orange.com/support
+
+

--- a/cf-ops-automation-sample-broker/curl_commands.txt
+++ b/cf-ops-automation-sample-broker/curl_commands.txt
@@ -24,3 +24,5 @@ curl http://user:secret@localhost:8080/v2/service_instances/111/service_bindings
     "parameter2-name-here": "parameter2-value-here"
   }
 }' -X PUT -H "Content-Type: application/json"
+
+curl http://user:secret@localhost:8080/v2/catalog -H "Content-Type: application/json"

--- a/cf-ops-automation-sample-broker/export_catalog_env_variable.sh
+++ b/cf-ops-automation-sample-broker/export_catalog_env_variable.sh
@@ -1,0 +1,2 @@
+#export catalog.yml file content as an env variable
+export CATALOG_YML="$(cat catalog.yml)"

--- a/cf-ops-automation-sample-broker/pom.xml
+++ b/cf-ops-automation-sample-broker/pom.xml
@@ -13,6 +13,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>cf-ops-automation-sample-broker</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -25,6 +26,11 @@
         <dependency>
             <groupId>com.orange.oss.cloudfoundry.broker.opsautomation</groupId>
             <artifactId>cf-ops-automation-broker-core</artifactId>
+            <version>0.0.1-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>com.orange.oss.cloudfoundry.broker.opsautomation</groupId>
+            <artifactId>spring-boot-starter-servicebroker-catalog</artifactId>
             <version>0.0.1-SNAPSHOT</version>
         </dependency>
         <dependency>

--- a/cf-ops-automation-sample-broker/src/main/java/com/orange/oss/cloudfoundry/broker/opsautomation/ondemandbroker/sample/BrokerCatalogConfig.java
+++ b/cf-ops-automation-sample-broker/src/main/java/com/orange/oss/cloudfoundry/broker/opsautomation/ondemandbroker/sample/BrokerCatalogConfig.java
@@ -4,11 +4,12 @@ import org.springframework.cloud.servicebroker.model.Catalog;
 import org.springframework.cloud.servicebroker.model.Plan;
 import org.springframework.cloud.servicebroker.model.ServiceDefinition;
 import org.springframework.context.annotation.Bean;
-import org.springframework.stereotype.Service;
+import org.springframework.context.annotation.Configuration;
 
 import java.util.*;
 
-@Service
+//Uncomment to override catalog configuration provided by spring-boot-starter-servicebroker-catalog
+//@Configuration
 public class BrokerCatalogConfig {
 	@Bean
 	public Catalog catalog() {

--- a/cf-ops-automation-sample-broker/src/main/resources/application.properties
+++ b/cf-ops-automation-sample-broker/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-security.user.password=secret

--- a/cf-ops-automation-sample-broker/src/main/resources/application.yml
+++ b/cf-ops-automation-sample-broker/src/main/resources/application.yml
@@ -1,0 +1,27 @@
+security:
+  user:
+    password: secret
+
+servicebroker:
+  catalog:
+    services:
+    - id: ondemand-service
+      name: ondemand
+      description: A simple ondemand service broker implementation
+      bindable: true
+      plans:
+        - id: ondemand-plan
+          name: default
+          description: This is a default ondemand plan.  All services are created equally.
+      tags:
+        -ondemand
+        -document
+      metadata:
+        displayName: ondemand
+        imageUrl: https://orange.com/image.png
+        longDescription: ondemand Service
+        providerDisplayName: Orange
+        documentationUrl: https://orange.com/doc
+        supportUrl: https://orange.com/support
+
+

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
         <module>cf-ops-automation-broker-core</module>
         <module>cf-ops-automation-broker-framework</module>
         <module>cf-ops-automation-sample-broker</module>
+        <module>spring-boot-starter-servicebroker-catalog</module>
     </modules>
 
     <dependencies>

--- a/spring-boot-starter-servicebroker-catalog/pom.xml
+++ b/spring-boot-starter-servicebroker-catalog/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>cf-ops-automation-broker</artifactId>
+        <groupId>com.orange.oss.cloudfoundry.broker.opsautomation</groupId>
+        <version>0.0.1-SNAPSHOT</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>spring-boot-starter-servicebroker-catalog</artifactId>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <java.version>1.8</java.version>
+        <gson.version>2.8.2</gson.version>
+    </properties>
+
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-cloudfoundry-service-broker</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>${gson.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/spring-boot-starter-servicebroker-catalog/src/main/java/com/orange/oss/cloudfoundry/broker/opsautomation/ondemandbroker/catalog/CatalogProperties.java
+++ b/spring-boot-starter-servicebroker-catalog/src/main/java/com/orange/oss/cloudfoundry/broker/opsautomation/ondemandbroker/catalog/CatalogProperties.java
@@ -1,0 +1,47 @@
+package com.orange.oss.cloudfoundry.broker.opsautomation.ondemandbroker.catalog;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import org.hibernate.validator.constraints.NotEmpty;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+import javax.validation.Valid;
+import javax.validation.constraints.Size;
+import java.util.List;
+
+/**
+ * Cloud Foundry Catalog
+ * http://docs.cloudfoundry.org/services/api.html
+ * Basically a duplicate of {@link org.springframework.cloud.servicebroker.model.Catalog Catalog}
+ * with setters and validation.
+ *
+ * @author Sebastien Bortolussi
+ */
+@ConfigurationProperties(prefix = "servicebroker.catalog")
+@Validated
+@ToString
+@Getter
+@Setter
+public class CatalogProperties {
+
+    public static final String NO_SERVICE_ERROR = "Invalid configuration. No service has been defined";
+
+    /**
+     * A list of service offerings provided by the service broker.
+     */
+    @NotEmpty
+    @Size(min = 1, message = NO_SERVICE_ERROR)
+    @Valid
+    private List<ServiceProperties> services;
+
+    public CatalogProperties() {
+    }
+
+    public List<ServiceProperties> getServices() {
+        return services;
+    }
+
+
+}

--- a/spring-boot-starter-servicebroker-catalog/src/main/java/com/orange/oss/cloudfoundry/broker/opsautomation/ondemandbroker/catalog/CatalogYamlPropertySourceMapper.java
+++ b/spring-boot-starter-servicebroker-catalog/src/main/java/com/orange/oss/cloudfoundry/broker/opsautomation/ondemandbroker/catalog/CatalogYamlPropertySourceMapper.java
@@ -1,0 +1,21 @@
+package com.orange.oss.cloudfoundry.broker.opsautomation.ondemandbroker.catalog;
+
+import org.springframework.boot.env.YamlPropertySourceLoader;
+import org.springframework.core.env.PropertySource;
+import org.springframework.core.io.Resource;
+
+import java.io.IOException;
+
+/**
+ * Utility class to map a Yaml {@link Resource}
+ * into a {@link PropertySource}.
+ *
+ * @author Sebastien Bortolussi
+ */
+public class CatalogYamlPropertySourceMapper {
+
+    public static PropertySource<?> toPropertySource(Resource catalogResource) throws IOException {
+        YamlPropertySourceLoader sourceLoader = new YamlPropertySourceLoader();
+        return sourceLoader.load("catalog_from_env_var", catalogResource, null);
+    }
+}

--- a/spring-boot-starter-servicebroker-catalog/src/main/java/com/orange/oss/cloudfoundry/broker/opsautomation/ondemandbroker/catalog/PlanProperties.java
+++ b/spring-boot-starter-servicebroker-catalog/src/main/java/com/orange/oss/cloudfoundry/broker/opsautomation/ondemandbroker/catalog/PlanProperties.java
@@ -1,0 +1,79 @@
+package com.orange.oss.cloudfoundry.broker.opsautomation.ondemandbroker.catalog;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import org.hibernate.validator.constraints.NotEmpty;
+
+import javax.validation.Valid;
+import java.lang.reflect.Type;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Cloud Foundry plan
+ * see http://docs.cloudfoundry.org/services/catalog-metadata.html#plan-metadata-fields
+ *
+ * Basically a duplicate of {@link org.springframework.cloud.servicebroker.model.Plan Plan}
+ * with setters and validation.
+ *
+ * @author Sebastien Bortolussi
+ */
+@Getter
+@Setter
+@ToString
+@EqualsAndHashCode
+public class PlanProperties {
+
+    public static final String NO_ID_ERROR = "Invalid configuration. No id has been set for plan";
+    public static final String NO_DESCRIPTION_ERROR = "Invalid configuration. No description has been set for service";
+
+    public static final String PLAN_NAME_DEFAULT = "default";
+
+    /**
+     * An identifier used to correlate this plan in future requests to the catalog. This must be unique within
+     * a Cloud Foundry deployment. Using a GUID is recommended.
+     */
+    @NotEmpty(message = NO_ID_ERROR)
+    private String id;
+
+    /**
+     * A CLI-friendly name of the plan that will appear in the catalog. The value should be all lowercase,
+     * with no spaces.
+     */
+    @NotEmpty
+    private String name = PLAN_NAME_DEFAULT;
+
+    /**
+     * A user-friendly short description of the plan that will appear in the catalog.
+     */
+    @NotEmpty(message = NO_DESCRIPTION_ERROR)
+    private String description;
+
+    /**
+     * map of metadata to further describe a service plan.
+     */
+    private Map<String, Object> metadata = new HashMap<>();
+
+    /**
+     * Indicates whether the service with this plan can be bound to applications. True by default.
+     */
+    private Boolean bindable;
+
+    /**
+     * Indicates whether the plan can be limited by the non_basic_services_allowed field in a Cloud Foundry Quota.
+     */
+    private Boolean free = Boolean.TRUE;
+
+    public PlanProperties() {
+    }
+
+    public void setMetadata(String metadataJson) {
+        Type type = new TypeToken<HashMap<String, Object>>() {
+        }.getType();
+        this.metadata = new Gson().fromJson(metadataJson, type);
+    }
+}

--- a/spring-boot-starter-servicebroker-catalog/src/main/java/com/orange/oss/cloudfoundry/broker/opsautomation/ondemandbroker/catalog/ServiceBrokerCatalogAutoConfiguration.java
+++ b/spring-boot-starter-servicebroker-catalog/src/main/java/com/orange/oss/cloudfoundry/broker/opsautomation/ondemandbroker/catalog/ServiceBrokerCatalogAutoConfiguration.java
@@ -1,0 +1,31 @@
+package com.orange.oss.cloudfoundry.broker.opsautomation.ondemandbroker.catalog;
+
+import com.orange.oss.cloudfoundry.broker.opsautomation.ondemandbroker.catalog.mapper.ServiceMapper;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cloud.servicebroker.model.Catalog;
+import org.springframework.cloud.servicebroker.model.ServiceDefinition;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+/**
+ * {@link EnableAutoConfiguration Auto-configuration} for
+ * {@link Catalog}.
+ *
+ * @author Sebastien Bortolussi
+ */
+@Configuration
+@ConditionalOnMissingBean(Catalog.class)
+@EnableConfigurationProperties(CatalogProperties.class)
+public class ServiceBrokerCatalogAutoConfiguration {
+
+    @Bean
+    public Catalog catalog(CatalogProperties properties) {
+        final List<ServiceDefinition> serviceDefinitions = ServiceMapper.toServiceDefinitions(properties.getServices());
+        return new Catalog(serviceDefinitions);
+    }
+
+}

--- a/spring-boot-starter-servicebroker-catalog/src/main/java/com/orange/oss/cloudfoundry/broker/opsautomation/ondemandbroker/catalog/ServiceProperties.java
+++ b/spring-boot-starter-servicebroker-catalog/src/main/java/com/orange/oss/cloudfoundry/broker/opsautomation/ondemandbroker/catalog/ServiceProperties.java
@@ -1,0 +1,93 @@
+package com.orange.oss.cloudfoundry.broker.opsautomation.ondemandbroker.catalog;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import org.hibernate.validator.constraints.NotEmpty;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
+
+import javax.validation.Valid;
+import javax.validation.constraints.Size;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Cloud Foundry ServiceProperties
+ * http://docs.cloudfoundry.org/services/api.html.
+ *
+ * Basically a duplicate of {@link org.springframework.cloud.servicebroker.model.ServiceDefinition ServiceDefinition }
+ * with setters and validation.
+ *
+ * @author Sebastien Bortolussi
+ */
+@Getter
+@Setter
+@ToString
+@EqualsAndHashCode
+public class ServiceProperties {
+
+    public static final String NO_ID_ERROR = "Invalid configuration. No id has been set for service";
+    public static final String NO_NAME_ERROR = "Invalid configuration. No name has been set for service";
+    public static final String NO_DESCRIPTION_ERROR = "Invalid configuration. No description has been set for service";
+    public static final String NO_PLAN_ERROR = "Invalid configuration. No plan has been set for service";
+
+    /**
+     * An identifier used to correlate this service in future requests to the catalog. This must be unique within
+     * a Cloud Foundry deployment. Using a GUID is recommended.
+     */
+    @NotEmpty(message = NO_ID_ERROR)
+    private String id;
+
+    /**
+     * A CLI-friendly name of the service that will appear in the catalog. The value should be all lowercase,
+     * with no spaces.
+     */
+    @NotEmpty(message = NO_NAME_ERROR)
+    private String name;
+
+    /**
+     * A user-friendly short description of the service that will appear in the catalog.
+     */
+    @NotEmpty(message = NO_DESCRIPTION_ERROR)
+    private String description;
+
+    /**
+     * Indicates whether the service can be bound to applications.
+     */
+    private Boolean bindable = Boolean.TRUE;
+
+    /**
+     * Indicates whether the service supports requests to update instances to use a different plan from the one
+     * used to provision a service instance.
+     */
+    private Boolean planUpdateable = Boolean.TRUE;
+
+    /**
+     * A list of plans for this service.
+     */
+    @Size(min=1,message = NO_PLAN_ERROR)
+    @Valid
+    private List<PlanProperties> plans = new ArrayList<>();
+
+    /**
+     * A list of tags to aid in categorizing and classifying services with similar characteristics.
+     */
+    private List<String> tags;
+
+    /**
+     * map of metadata to further describe a service offering.
+     */
+    private Map<String, Object> metadata;
+
+
+    /**
+     * A list of permissions that the user would have to give the service, if they provision it.
+     */
+    private List<String> requires;
+
+    public ServiceProperties() {
+    }
+
+}

--- a/spring-boot-starter-servicebroker-catalog/src/main/java/com/orange/oss/cloudfoundry/broker/opsautomation/ondemandbroker/catalog/YamlCataloglAsEnvironmentVarApplicationContextInitializer.java
+++ b/spring-boot-starter-servicebroker-catalog/src/main/java/com/orange/oss/cloudfoundry/broker/opsautomation/ondemandbroker/catalog/YamlCataloglAsEnvironmentVarApplicationContextInitializer.java
@@ -1,0 +1,45 @@
+package com.orange.oss.cloudfoundry.broker.opsautomation.ondemandbroker.catalog;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.core.env.PropertySource;
+import org.springframework.core.io.Resource;
+import org.springframework.security.util.InMemoryResource;
+
+import java.io.IOException;
+
+import static org.springframework.util.StringUtils.isEmpty;
+
+/**
+ * An  {@link ApplicationContextInitializer} to register a {@link PropertySource} from
+ * CATALOG_YML environment variable that contains service broker catalog configuration in a Yaml format.
+ *
+ * @author Sebastien Bortolussi
+ */
+public class YamlCataloglAsEnvironmentVarApplicationContextInitializer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+
+    public static final String CATALOG_YML = "CATALOG_YML";
+
+    private static Logger LOGGER = LoggerFactory.getLogger(YamlCataloglAsEnvironmentVarApplicationContextInitializer.class.getName());
+
+    @Override
+    public void initialize(ConfigurableApplicationContext configurableApplicationContext) {
+        try {
+            String yml = configurableApplicationContext.getEnvironment().getProperty(CATALOG_YML);
+            if (isEmpty(yml)) {
+                return;
+            }
+            LOGGER.info("CATALOG_YML environment variable is set with content : {}", yml);
+            Resource resource = new InMemoryResource(yml);
+            LOGGER.info("Using CATALOG_YML environment variable to set service broker catalog.");
+            PropertySource<?> propertySource = CatalogYamlPropertySourceMapper.toPropertySource(resource);
+            configurableApplicationContext.getEnvironment().getPropertySources().addFirst(propertySource);
+        } catch (IOException e) {
+            throw new IllegalStateException("Unable to read CATALOG_YML environment variable.",e);
+        }
+    }
+
+
+}

--- a/spring-boot-starter-servicebroker-catalog/src/main/java/com/orange/oss/cloudfoundry/broker/opsautomation/ondemandbroker/catalog/mapper/PlanMapper.java
+++ b/spring-boot-starter-servicebroker-catalog/src/main/java/com/orange/oss/cloudfoundry/broker/opsautomation/ondemandbroker/catalog/mapper/PlanMapper.java
@@ -1,0 +1,30 @@
+package com.orange.oss.cloudfoundry.broker.opsautomation.ondemandbroker.catalog.mapper;
+
+import com.orange.oss.cloudfoundry.broker.opsautomation.ondemandbroker.catalog.PlanProperties;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Service plan internal mapper
+ *
+ * @author Sebastien Bortolussi
+ */
+public class PlanMapper {
+
+
+    public static org.springframework.cloud.servicebroker.model.Plan toServiceBrokerPlan(PlanProperties planProperties) {
+
+        return new org.springframework.cloud.servicebroker.model.Plan(planProperties.getId(),
+                planProperties.getName(),
+                planProperties.getDescription(),
+                planProperties.getMetadata() ,
+                planProperties.getFree());
+    }
+
+    public static List<org.springframework.cloud.servicebroker.model.Plan> toServiceBrokerPlans(List<PlanProperties> planProperties) {
+        return planProperties.stream()
+                .map(PlanMapper::toServiceBrokerPlan)
+                .collect(Collectors.toList());
+    }
+}

--- a/spring-boot-starter-servicebroker-catalog/src/main/java/com/orange/oss/cloudfoundry/broker/opsautomation/ondemandbroker/catalog/mapper/ServiceMapper.java
+++ b/spring-boot-starter-servicebroker-catalog/src/main/java/com/orange/oss/cloudfoundry/broker/opsautomation/ondemandbroker/catalog/mapper/ServiceMapper.java
@@ -1,0 +1,34 @@
+package com.orange.oss.cloudfoundry.broker.opsautomation.ondemandbroker.catalog.mapper;
+
+import com.orange.oss.cloudfoundry.broker.opsautomation.ondemandbroker.catalog.ServiceProperties;
+import org.springframework.cloud.servicebroker.model.ServiceDefinition;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Service internal mapper
+ *
+ * @author Sebastien Bortolussi
+ */
+public class ServiceMapper {
+
+    public static ServiceDefinition toServiceDefinition(ServiceProperties serviceProperties) {
+        return new ServiceDefinition(serviceProperties.getId().toString(),
+                serviceProperties.getName(),
+                serviceProperties.getDescription(),
+                serviceProperties.getBindable(),
+                serviceProperties.getPlanUpdateable(),
+                PlanMapper.toServiceBrokerPlans(serviceProperties.getPlans()),
+                serviceProperties.getTags(),
+                serviceProperties.getMetadata(),
+                serviceProperties.getRequires(),
+                null);
+    }
+
+    public static List<ServiceDefinition> toServiceDefinitions(List<ServiceProperties> serviceProperties) {
+        return serviceProperties.stream()
+                .map(ServiceMapper::toServiceDefinition)
+                .collect(Collectors.toList());
+    }
+}

--- a/spring-boot-starter-servicebroker-catalog/src/main/resources/META-INF/spring.factories
+++ b/spring-boot-starter-servicebroker-catalog/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,4 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+com.orange.oss.cloudfoundry.broker.opsautomation.ondemandbroker.catalog.ServiceBrokerCatalogAutoConfiguration
+org.springframework.context.ApplicationContextInitializer=\
+com.orange.oss.cloudfoundry.broker.opsautomation.ondemandbroker.catalog.YamlCataloglAsEnvironmentVarApplicationContextInitializer

--- a/spring-boot-starter-servicebroker-catalog/src/test/java/com/orange/oss/cloudfoundry/broker/opsautomation/ondemandbroker/catalog/CatalogYamlPropertySourceMapperTest.java
+++ b/spring-boot-starter-servicebroker-catalog/src/test/java/com/orange/oss/cloudfoundry/broker/opsautomation/ondemandbroker/catalog/CatalogYamlPropertySourceMapperTest.java
@@ -1,0 +1,58 @@
+package com.orange.oss.cloudfoundry.broker.opsautomation.ondemandbroker.catalog;
+
+import org.fest.assertions.Assertions;
+import org.junit.Test;
+import org.springframework.core.env.PropertySource;
+import org.springframework.core.io.Resource;
+import org.springframework.security.util.InMemoryResource;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class CatalogYamlPropertySourceMapperTest {
+
+    public static final String CATALOG_YML = "servicebroker:\n" +
+            "  catalog:\n" +
+            "    services:\n" +
+            "    - id: ondemand-service\n" +
+            "      name: ondemand\n" +
+            "      description: try a simple ondemand service broker implementation\n" +
+            "      bindable: true\n" +
+            "      plans:\n" +
+            "        - id: ondemand-plan\n" +
+            "          name: default\n" +
+            "          description: This is a default ondemand plan.  All services are created equally.\n" +
+            "      tags:\n" +
+            "        -ondemand\n" +
+            "        -document\n" +
+            "      metadata:\n" +
+            "        displayName: ondemand\n" +
+            "        imageUrl: https://orange.com/image.png\n" +
+            "        longDescription: ondemand Service\n" +
+            "        providerDisplayName: Orange\n" +
+            "        documentationUrl: https://orange.com/doc\n" +
+            "        supportUrl: https://orange.com/support\n" +
+            "\n" +
+            "\n";
+
+    @Test
+    public void should_map_a_yml_catalog_into_property_source() throws Exception {
+        Resource resource = new InMemoryResource(CATALOG_YML);
+
+        PropertySource<?> propertySource = CatalogYamlPropertySourceMapper.toPropertySource(resource);
+
+        //very basic assertions
+        Assertions.assertThat(propertySource.getProperty("servicebroker.catalog.services[0].id")).isEqualTo("ondemand-service");
+        Assertions.assertThat(propertySource.getProperty("servicebroker.catalog.services[0].plans[0].id")).isEqualTo("ondemand-plan");
+    }
+
+    @Test
+    public void fail_to_map_invalid_yml_catalog_into_property_source() throws Exception {
+        //invalid yml syntax
+        String catalogYml = "servicebroker: catalog:\n";
+        Resource resource = new InMemoryResource(catalogYml);
+
+        assertThatThrownBy(() -> {
+            CatalogYamlPropertySourceMapper.toPropertySource(resource);
+        }).hasMessageContaining("mapping values are not allowed here");
+    }
+}

--- a/spring-boot-starter-servicebroker-catalog/src/test/java/com/orange/oss/cloudfoundry/broker/opsautomation/ondemandbroker/catalog/YamlCataloglAsEnvironmentVarApplicationContextInitializerTest.java
+++ b/spring-boot-starter-servicebroker-catalog/src/test/java/com/orange/oss/cloudfoundry/broker/opsautomation/ondemandbroker/catalog/YamlCataloglAsEnvironmentVarApplicationContextInitializerTest.java
@@ -1,0 +1,57 @@
+package com.orange.oss.cloudfoundry.broker.opsautomation.ondemandbroker.catalog;
+
+import org.fest.assertions.Assertions;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.context.support.StaticApplicationContext;
+
+public class YamlCataloglAsEnvironmentVarApplicationContextInitializerTest {
+
+    @Before
+    public void init() {
+        System.setProperty("CATALOG_YML", CATALOG_YML);
+        Assertions.assertThat(System.getProperty("CATALOG_YML")).isNotEmpty();
+    }
+
+    @After
+    public void after() {
+        System.clearProperty("CATALOG_YML");
+        Assertions.assertThat(System.getProperty("CATALOG_YML")).isNull();
+    }
+
+    private final YamlCataloglAsEnvironmentVarApplicationContextInitializer contextInitializer = new YamlCataloglAsEnvironmentVarApplicationContextInitializer();
+
+    public static final String CATALOG_YML = "servicebroker:\n" +
+            "  catalog:\n" +
+            "    services:\n" +
+            "    - id: ondemand-service\n" +
+            "      name: ondemand\n" +
+            "      description: try a simple ondemand service broker implementation\n" +
+            "      bindable: true\n" +
+            "      plans:\n" +
+            "        - id: ondemand-plan\n" +
+            "          name: default\n" +
+            "          description: This is a default ondemand plan.  All services are created equally.\n" +
+            "      tags:\n" +
+            "        -ondemand\n" +
+            "        -document\n" +
+            "      metadata:\n" +
+            "        displayName: ondemand\n" +
+            "        imageUrl: https://orange.com/image.png\n" +
+            "        longDescription: ondemand Service\n" +
+            "        providerDisplayName: Orange\n" +
+            "        documentationUrl: https://orange.com/doc\n" +
+            "        supportUrl: https://orange.com/support\n" +
+            "\n" +
+            "\n";
+
+    @Test
+    public void initialize() throws Exception {
+        StaticApplicationContext context = new StaticApplicationContext();
+
+        contextInitializer.initialize(context);
+
+        Assertions.assertThat(context.getEnvironment().getPropertySources().contains("catalog_from_env_var")).isTrue();
+    }
+}

--- a/spring-boot-starter-servicebroker-catalog/src/test/java/com/orange/oss/cloudfoundry/broker/opsautomation/ondemandbroker/catalog/mapper/PlanMapperTest.java
+++ b/spring-boot-starter-servicebroker-catalog/src/test/java/com/orange/oss/cloudfoundry/broker/opsautomation/ondemandbroker/catalog/mapper/PlanMapperTest.java
@@ -1,0 +1,100 @@
+package com.orange.oss.cloudfoundry.broker.opsautomation.ondemandbroker.catalog.mapper;
+
+import com.orange.oss.cloudfoundry.broker.opsautomation.ondemandbroker.catalog.PlanProperties;
+import com.orange.oss.cloudfoundry.broker.opsautomation.ondemandbroker.catalog.mapper.PlanMapper;
+import org.fest.assertions.Assertions;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.fest.assertions.MapAssert.entry;
+
+
+public class PlanMapperTest {
+
+    public static final String PLAN_NAME = "dev";
+    public static final String PLAN_DESCRIPTION = "a description";
+    public static final String PLAN_DEV_ID = "dev";
+    public static final String PLAN_DEFAULT_ID = "default";
+
+
+    @Test
+    public void should_map_plan_name() throws Exception {
+
+        PlanProperties planProperties = new PlanProperties();
+        planProperties.setId(PLAN_DEV_ID);
+        planProperties.setName(PLAN_NAME);
+
+        org.springframework.cloud.servicebroker.model.Plan res = PlanMapper.toServiceBrokerPlan(planProperties);
+
+        Assertions.assertThat(res.getName()).as("toServiceDefinition plan name").isEqualTo(PLAN_NAME);
+    }
+
+    @Test
+    public void should_map_plan_description() throws Exception {
+
+        PlanProperties planProperties = new PlanProperties();
+        planProperties.setId(PLAN_DEV_ID);
+        planProperties.setDescription(PLAN_DESCRIPTION);
+
+        org.springframework.cloud.servicebroker.model.Plan res = PlanMapper.toServiceBrokerPlan(planProperties);
+
+        Assertions.assertThat(res.getDescription()).as("toServiceDefinition plan description").isEqualTo(PLAN_DESCRIPTION);
+    }
+
+    @Test
+    public void should_map_plan_id() throws Exception {
+
+        PlanProperties planProperties = new PlanProperties();
+        planProperties.setId(PLAN_DEV_ID);
+
+        org.springframework.cloud.servicebroker.model.Plan res = PlanMapper.toServiceBrokerPlan(planProperties);
+
+        Assertions.assertThat(res.getId()).as("toServiceDefinition plan id").isEqualTo(PLAN_DEV_ID.toString());
+    }
+
+    @Test
+    public void should_map_plan_metadata() throws Exception {
+
+        PlanProperties planProperties = new PlanProperties();
+        planProperties.setId(PLAN_DEV_ID);
+
+        planProperties.setMetadata("{\"bullets\":[\"20 GB of messages\",\"20 connections\"],\"costs\":[{\"amount\":{\"usd\":99.0,\"eur\":49.0},\"unit\":\"MONTHLY\"},{\"amount\":{\"usd\":0.99,\"eur\":0.49},\"unit\":\"1GB of messages over 20GB\"}],\"displayName\":\"Big Bunny\"}");
+
+        org.springframework.cloud.servicebroker.model.Plan res = PlanMapper.toServiceBrokerPlan(planProperties);
+
+        Assertions.assertThat(res.getMetadata()).as("toServiceDefinition plan metadata").hasSize(3).includes(
+                entry("displayName", "Big Bunny"));
+        //TODO assert bullets mapping
+        //TODO assert costs mapping
+    }
+
+    @Test
+    public void should_map_plan_free() throws Exception {
+
+        PlanProperties planProperties = new PlanProperties();
+        planProperties.setId(PLAN_DEV_ID);
+
+        planProperties.setFree(Boolean.FALSE);
+
+        org.springframework.cloud.servicebroker.model.Plan res = PlanMapper.toServiceBrokerPlan(planProperties);
+
+        Assertions.assertThat(res.isFree()).as("toServiceDefinition plan free").isFalse();
+    }
+
+    @Test
+    public void should_map_plans() throws Exception {
+
+        PlanProperties plan_Properties_default = new PlanProperties();
+        plan_Properties_default.setId(PLAN_DEV_ID);
+
+        PlanProperties plan_Properties_prod = new PlanProperties();
+        plan_Properties_prod.setId(PLAN_DEFAULT_ID);
+
+
+        List<org.springframework.cloud.servicebroker.model.Plan> res = PlanMapper.toServiceBrokerPlans(Arrays.asList(plan_Properties_default, plan_Properties_prod));
+
+        Assertions.assertThat(res).as("toServiceDefinition plan_dev free").hasSize(2);
+    }
+}

--- a/spring-boot-starter-servicebroker-catalog/src/test/java/com/orange/oss/cloudfoundry/broker/opsautomation/ondemandbroker/catalog/mapper/ServiceMapperTest.java
+++ b/spring-boot-starter-servicebroker-catalog/src/test/java/com/orange/oss/cloudfoundry/broker/opsautomation/ondemandbroker/catalog/mapper/ServiceMapperTest.java
@@ -1,0 +1,174 @@
+package com.orange.oss.cloudfoundry.broker.opsautomation.ondemandbroker.catalog.mapper;
+
+import com.orange.oss.cloudfoundry.broker.opsautomation.ondemandbroker.catalog.ServiceProperties;
+import org.fest.assertions.Assertions;
+import org.junit.Test;
+import org.springframework.cloud.servicebroker.model.ServiceDefinition;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.fest.assertions.MapAssert.entry;
+
+public class ServiceMapperTest {
+
+    public static final String SERVICE_ID = "a service id";
+    public static final String SERVICE_DESCRIPTION = "a description";
+    public static final String SERVICE_NAME = "a service name";
+
+    @Test
+    public void map_service_id() {
+        //GIVEN
+        ServiceProperties serviceProperties = new ServiceProperties();
+        serviceProperties.setId(SERVICE_ID);
+        //WHEN
+        final ServiceDefinition res = ServiceMapper.toServiceDefinition(serviceProperties);
+        //THEN
+        Assertions.assertThat(res.getId()).as("toServiceDefinition serviceProperties id").isEqualTo(SERVICE_ID.toString());
+    }
+
+    @Test
+    public void map_service_description() {
+        //GIVEN
+        ServiceProperties serviceProperties = new ServiceProperties();
+        serviceProperties.setId(SERVICE_ID);
+        serviceProperties.setDescription(SERVICE_DESCRIPTION);
+        //WHEN
+        final ServiceDefinition res = ServiceMapper.toServiceDefinition(serviceProperties);
+        //THEN
+        Assertions.assertThat(res.getDescription()).as("toServiceDefinition serviceProperties description").isEqualTo(SERVICE_DESCRIPTION);
+    }
+
+    @Test
+    public void map_service_name() {
+        //GIVEN
+        ServiceProperties serviceProperties = new ServiceProperties();
+        serviceProperties.setId(SERVICE_ID);
+        serviceProperties.setName(SERVICE_NAME);
+        //WHEN
+        final ServiceDefinition res = ServiceMapper.toServiceDefinition(serviceProperties);
+        //THEN
+        Assertions.assertThat(res.getName()).as("toServiceDefinition serviceProperties name").isEqualTo(SERVICE_NAME);
+    }
+
+    @Test
+    public void map_service_bindable() {
+        //GIVEN
+        ServiceProperties serviceProperties = new ServiceProperties();
+        serviceProperties.setId(SERVICE_ID);
+        serviceProperties.setBindable(Boolean.FALSE);
+        //WHEN
+        final ServiceDefinition res = ServiceMapper.toServiceDefinition(serviceProperties);
+        //THEN
+        Assertions.assertThat(res.isBindable()).as("toServiceDefinition serviceProperties bindable").isFalse();
+    }
+
+    @Test
+    public void map_service_requires() {
+        //GIVEN
+        ServiceProperties serviceProperties = new ServiceProperties();
+        serviceProperties.setId(SERVICE_ID);
+        serviceProperties.setRequires(Arrays.asList("syslog_drain"));
+        //WHEN
+        final ServiceDefinition res = ServiceMapper.toServiceDefinition(serviceProperties);
+        //THEN
+        Assertions.assertThat(res.getRequires()).as("toServiceDefinition serviceProperties requires")
+                .containsExactly("syslog_drain");
+    }
+
+    @Test
+    public void map_service_plan_updateable() {
+        //GIVEN
+        ServiceProperties serviceProperties = new ServiceProperties();
+        serviceProperties.setId(SERVICE_ID);
+        serviceProperties.setPlanUpdateable(Boolean.FALSE);
+        //WHEN
+        final ServiceDefinition res = ServiceMapper.toServiceDefinition(serviceProperties);
+        //THEN
+        Assertions.assertThat(res.isPlanUpdateable()).as("toServiceDefinition serviceProperties plan updateable").isFalse();
+    }
+
+    @Test
+    public void map_service_metadata() {
+        //GIVEN
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put("displayName", "aDisplayName");
+        metadata.put("longDescription", "a long description");
+        metadata.put("providerDisplayName", "a provider");
+        metadata.put("documentationUrl", "http://localhost/doc");
+        metadata.put("imageUrl", "http://localhost/image.png");
+        metadata.put("supportUrl", "http://localhost/support");
+
+        ServiceProperties serviceProperties = new ServiceProperties();
+        serviceProperties.setId(SERVICE_ID);
+        serviceProperties.setMetadata(metadata);
+
+        //WHEN
+        final ServiceDefinition res = ServiceMapper.toServiceDefinition(serviceProperties);
+        //THEN
+        Assertions.assertThat(res.getMetadata()).as("toServiceDefinition serviceProperties metadata").hasSize(6).includes(
+                entry("displayName", "aDisplayName"),
+                entry("longDescription", "a long description"),
+                entry("providerDisplayName", "a provider"),
+                entry("documentationUrl", "http://localhost/doc"),
+                entry("imageUrl", "http://localhost/image.png"),
+                entry("supportUrl", "http://localhost/support"));
+    }
+
+    @Test
+    public void map_service_tags() {
+        //GIVEN
+        ServiceProperties serviceProperties = new ServiceProperties();
+        serviceProperties.setId(SERVICE_ID);
+        serviceProperties.setTags(Stream.of("tag1", "tag2", "tag3").collect(Collectors.toList()));
+
+        //WHEN
+        final ServiceDefinition res = ServiceMapper.toServiceDefinition(serviceProperties);
+        //THEN
+        Assertions.assertThat(res.getTags()).as("toServiceDefinition serviceProperties tags").containsOnly("tag1", "tag2", "tag3");
+    }
+
+    @Test
+    public void does_not_map_requires() {
+        //GIVEN
+        ServiceProperties serviceProperties = new ServiceProperties();
+        serviceProperties.setId(SERVICE_ID);
+        //WHEN
+        final ServiceDefinition res = ServiceMapper.toServiceDefinition(serviceProperties);
+        //THEN
+        Assertions.assertThat(res.getRequires()).as("does not toServiceDefinition requires").isNull();
+    }
+
+    @Test
+    public void does_not_map_dashboard_client() {
+        //GIVEN
+        ServiceProperties serviceProperties = new ServiceProperties();
+        serviceProperties.setId(SERVICE_ID);
+        //WHEN
+        final ServiceDefinition res = ServiceMapper.toServiceDefinition(serviceProperties);
+        //THEN
+        Assertions.assertThat(res.getDashboardClient()).as("does not toServiceDefinition dashboard client").isNull();
+    }
+
+    public void should_map_services() {
+        //GIVEN
+        final String aServiceId = "a service id";
+        ServiceProperties aServiceProperties = new ServiceProperties();
+        aServiceProperties.setId(aServiceId);
+        final String anotherServiceId = "another service id";
+        ServiceProperties anotherServiceProperties = new ServiceProperties();
+        anotherServiceProperties.setId(anotherServiceId);
+        //WHEN
+        final List<ServiceDefinition> serviceDefinitions = ServiceMapper.toServiceDefinitions(Arrays.asList(aServiceProperties, anotherServiceProperties));
+        //THEN
+        Assertions.assertThat(serviceDefinitions).as("map services to service definitions").hasSize(2);
+        Assertions.assertThat(serviceDefinitions.stream().map(ServiceDefinition::getId).collect(Collectors.toList())).as("map services to service definitions").containsOnly(aServiceId, anotherServiceId);
+
+
+    }
+
+}


### PR DESCRIPTION
Theses changes add support to auto-configure service broker catalog when no Catalog bean is provided. On missing Catalog bean, the starter will auto configure one using properties files, YAML files, environment variables or command-line arguments.

[#10]