### PR TITLE
Refine git processor traces and fix locking of COA consistency check pipeline upon rejected git push on OSB delete 

### DIFF
--- a/cf-ops-automation-broker-core/src/main/java/com/orange/oss/cloudfoundry/broker/opsautomation/ondemandbroker/git/SimpleGitManager.java
+++ b/cf-ops-automation-broker-core/src/main/java/com/orange/oss/cloudfoundry/broker/opsautomation/ondemandbroker/git/SimpleGitManager.java
@@ -409,7 +409,7 @@ public class SimpleGitManager implements GitManager {
                 if (!pullRebaseResult.isSuccessful()) {
                     logger.error(prefixLog("Failed to pull rebase: ") + pullBaseResultToString);
                     throw new RuntimeException("failed to push with status=" + failedStatuses
-                        + "pull rebase also failed:" + pullRebaseResult);
+                        + ", pull rebase also failed :" + pullRebaseResult + " (see full details in logs)");
                     //intentionally displays org.eclipse.jgit .transport.FetchResult@27fd0b86
                     //to avoid leaking credentials despite RuntimeException filtering
                 }

--- a/cf-ops-automation-broker-core/src/test/java/com/orange/oss/cloudfoundry/broker/opsautomation/ondemandbroker/git/SimpleGitManagerTest.java
+++ b/cf-ops-automation-broker-core/src/test/java/com/orange/oss/cloudfoundry/broker/opsautomation/ondemandbroker/git/SimpleGitManagerTest.java
@@ -899,7 +899,7 @@ public class SimpleGitManagerTest {
             processor1.commitPushRepo(ctx1, true);
             Assert.fail("expected exception");
         } catch (RuntimeException e) {
-            assertThat(e.getMessage()).contains("conflict");
+            assertThat(e.getMessage()).contains("REJECTED_NONFASTFORWARD");
         }
     }
 

--- a/cf-ops-automation-broker-framework/src/main/java/com/orange/oss/cloudfoundry/broker/opsautomation/ondemandbroker/processors/ProcessorChain.java
+++ b/cf-ops-automation-broker-framework/src/main/java/com/orange/oss/cloudfoundry/broker/opsautomation/ondemandbroker/processors/ProcessorChain.java
@@ -11,46 +11,46 @@ public class ProcessorChain {
 
 	private static Logger logger=LoggerFactory.getLogger(ProcessorChain.class.getName());
 	
-	private List<BrokerProcessor> processors;
+	private List<BrokerProcessor> defaultProcessors;
 	private BrokerSink sink;
 	
-	public ProcessorChain(List<BrokerProcessor> processors, BrokerSink sink) {
-		this.processors = processors;
+	public ProcessorChain(List<BrokerProcessor> defaultProcessors, BrokerSink sink) {
+		this.defaultProcessors = defaultProcessors;
 		this.sink=sink;
 	}
 
 	public void create(Context ctx) {
 		try {
-			for (BrokerProcessor m : processors) {
+			for (BrokerProcessor m : defaultProcessors) {
 				m.preCreate(ctx);
 			}
 			sink.create(ctx);
 
-			for (int i = processors.size() - 1; i >= 0; i--) {
-				BrokerProcessor m = processors.get(i);
+			for (int i = defaultProcessors.size() - 1; i >= 0; i--) {
+				BrokerProcessor m = defaultProcessors.get(i);
 				m.postCreate(ctx);
 			}
 		} finally {
-			for (int i = processors.size() - 1; i >= 0; i--) {
-				BrokerProcessor m = processors.get(i);
+			for (int i = defaultProcessors.size() - 1; i >= 0; i--) {
+				BrokerProcessor m = defaultProcessors.get(i);
 				m.cleanUp(ctx);
 			}
 		}
 	}
 	public void getInstance(Context ctx) {
 		try {
-			for (BrokerProcessor m : processors) {
+			for (BrokerProcessor m : defaultProcessors) {
 				m.preGetInstance(ctx);
 			}
 			sink.getInstance(ctx);
 
-			for (int i = processors.size() - 1; i >= 0; i--) {
-				BrokerProcessor m = processors.get(i);
+			for (int i = defaultProcessors.size() - 1; i >= 0; i--) {
+				BrokerProcessor m = defaultProcessors.get(i);
 				m.postGetInstance(ctx);
 			}
 		} finally {
-			for (int i = processors.size() - 1; i >= 0; i--) {
-				BrokerProcessor m = processors.get(i);
+			for (int i = defaultProcessors.size() - 1; i >= 0; i--) {
+				BrokerProcessor m = defaultProcessors.get(i);
 				m.cleanUp(ctx);
 			}
 		}
@@ -58,18 +58,18 @@ public class ProcessorChain {
 
 	public void getLastOperation(Context ctx) {
 		try {
-			for (BrokerProcessor m: processors) {
+			for (BrokerProcessor m: defaultProcessors) {
                 m.preGetLastOperation(ctx);
             }
 			sink.getLastOperation(ctx);
 
-			for (int i = processors.size()-1; i>=0; i--) {
-                BrokerProcessor m= processors.get(i);
+			for (int i = defaultProcessors.size()-1; i>=0; i--) {
+                BrokerProcessor m= defaultProcessors.get(i);
 				m.postGetLastOperation(ctx);
             }
 		} finally {
-			for (int i = processors.size() - 1; i >= 0; i--) {
-				BrokerProcessor m = processors.get(i);
+			for (int i = defaultProcessors.size() - 1; i >= 0; i--) {
+				BrokerProcessor m = defaultProcessors.get(i);
 				m.cleanUp(ctx);
 			}
 		}
@@ -77,18 +77,18 @@ public class ProcessorChain {
 
 	public void bind(Context ctx) {
 		try {
-			for (BrokerProcessor m: processors) {
+			for (BrokerProcessor m: defaultProcessors) {
                 m.preBind(ctx);
             }
 			sink.bind(ctx);
 
-			for (int i = processors.size()-1; i>=0; i--) {
-                BrokerProcessor m= processors.get(i);
+			for (int i = defaultProcessors.size()-1; i>=0; i--) {
+                BrokerProcessor m= defaultProcessors.get(i);
 				m.postBind(ctx);
             }
 		} finally {
-			for (int i = processors.size() - 1; i >= 0; i--) {
-				BrokerProcessor m = processors.get(i);
+			for (int i = defaultProcessors.size() - 1; i >= 0; i--) {
+				BrokerProcessor m = defaultProcessors.get(i);
 				m.cleanUp(ctx);
 			}
 		}
@@ -98,18 +98,18 @@ public class ProcessorChain {
 
 	public void unBind(Context ctx) {
 		try {
-			for (BrokerProcessor m: processors) {
+			for (BrokerProcessor m: defaultProcessors) {
                 m.preUnBind(ctx);
             }
 			sink.unBind(ctx);
 
-			for (int i = processors.size()-1; i>=0; i--) {
-                BrokerProcessor m= processors.get(i);
+			for (int i = defaultProcessors.size()-1; i>=0; i--) {
+                BrokerProcessor m= defaultProcessors.get(i);
 				m.postUnBind(ctx);
             }
 		} finally {
-			for (int i = processors.size() - 1; i >= 0; i--) {
-				BrokerProcessor m = processors.get(i);
+			for (int i = defaultProcessors.size() - 1; i >= 0; i--) {
+				BrokerProcessor m = defaultProcessors.get(i);
 				m.cleanUp(ctx);
 			}
 		}
@@ -118,18 +118,18 @@ public class ProcessorChain {
 
 	public void update(Context ctx) {
 		try {
-			for (BrokerProcessor m: processors) {
+			for (BrokerProcessor m: defaultProcessors) {
                 m.preUpdate(ctx);
             }
 			sink.update(ctx);
 
-			for (int i = processors.size()-1; i>=0; i--) {
-                BrokerProcessor m= processors.get(i);
+			for (int i = defaultProcessors.size()-1; i>=0; i--) {
+                BrokerProcessor m= defaultProcessors.get(i);
 				m.postUpdate(ctx);
             }
 		} finally {
-			for (int i = processors.size() - 1; i >= 0; i--) {
-				BrokerProcessor m = processors.get(i);
+			for (int i = defaultProcessors.size() - 1; i >= 0; i--) {
+				BrokerProcessor m = defaultProcessors.get(i);
 				m.cleanUp(ctx);
 			}
 		}
@@ -137,18 +137,18 @@ public class ProcessorChain {
 
 	public void delete(Context ctx) {
 		try {
-			for (BrokerProcessor m: processors) {
+			for (BrokerProcessor m: defaultProcessors) {
                 m.preDelete(ctx);
             }
 			sink.delete(ctx);
 
-			for (int i = processors.size()-1; i>=0; i--) {
-                BrokerProcessor m= processors.get(i);
+			for (int i = defaultProcessors.size()-1; i>=0; i--) {
+                BrokerProcessor m= defaultProcessors.get(i);
 				m.postDelete(ctx);
             }
 		} finally {
-			for (int i = processors.size() - 1; i >= 0; i--) {
-				BrokerProcessor m = processors.get(i);
+			for (int i = defaultProcessors.size() - 1; i >= 0; i--) {
+				BrokerProcessor m = defaultProcessors.get(i);
 				m.cleanUp(ctx);
 			}
 		}

--- a/cf-ops-automation-broker-framework/src/test/java/com/orange/oss/cloudfoundry/broker/opsautomation/ondemandbroker/processors/ProcessorChainTest.java
+++ b/cf-ops-automation-broker-framework/src/test/java/com/orange/oss/cloudfoundry/broker/opsautomation/ondemandbroker/processors/ProcessorChainTest.java
@@ -1,6 +1,5 @@
 package com.orange.oss.cloudfoundry.broker.opsautomation.ondemandbroker.processors;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -16,176 +15,189 @@ public class ProcessorChainTest {
 
 	private static Logger logger=LoggerFactory.getLogger(ProcessorChainTest.class.getName());
 
-	private ProcessorChain chain;
-
 	private final ArrayList<String> invocations = new ArrayList<>();
-	@BeforeEach
-	public void setUp() {
-		List<BrokerProcessor> defaultProcessors= new ArrayList<>();
-		defaultProcessors.add(new BrokerProcessor() {
 
-			@Override
-			public void preCreate(Context ctx) {
-				recordInvocation("preCreate 1");
-			}
+	private BrokerProcessor processor1 = new BrokerProcessor() {
 
-			@Override
-			public void preBind(Context ctx) {
-				recordInvocation("preBind 1");
-			}
+		@Override
+		public void preCreate(Context ctx) {
+			recordInvocation("preCreate 1");
+		}
 
-			@Override
-			public void preGetLastOperation(Context ctx) { recordInvocation("preGetLastCreateOperation 1"); }
+		@Override
+		public void preBind(Context ctx) {
+			recordInvocation("preBind 1");
+		}
 
-			@Override
-			public void postCreate(Context ctx) {
-				recordInvocation("post Create 1");
-			}
+		@Override
+		public void preGetLastOperation(Context ctx) {
+			recordInvocation("preGetLastCreateOperation 1");
+		}
 
-			@Override
-			public void postGetLastOperation(Context ctx) { recordInvocation("preGetLastCreateOperation 1"); }
+		@Override
+		public void postCreate(Context ctx) {
+			recordInvocation("post Create 1");
+		}
 
-			@Override
-			public void postBind(Context ctx) {
-				recordInvocation("post Bind 1");
-			}
+		@Override
+		public void postGetLastOperation(Context ctx) {
+			recordInvocation("preGetLastCreateOperation 1");
+		}
 
-			@Override
-			public void cleanUp(Context ctx) {
-				recordInvocation("cleanUp 1");
-			}
+		@Override
+		public void postBind(Context ctx) {
+			recordInvocation("post Bind 1");
+		}
 
-			@Override
-			public void preDelete(Context ctx) {
-				recordInvocation("pre delete 1");
+		@Override
+		public void cleanUp(Context ctx) {
+			recordInvocation("cleanUp 1");
+		}
 
-			}
+		@Override
+		public void preDelete(Context ctx) {
+			recordInvocation("pre delete 1");
 
-			@Override
-			public void postDelete(Context ctx) {
-				recordInvocation("post delete 1");
+		}
 
-			}
+		@Override
+		public void postDelete(Context ctx) {
+			recordInvocation("post delete 1");
 
-			@Override
-			public void preUnBind(Context ctx) {
-				recordInvocation("pre unbind 1");
+		}
 
-			}
+		@Override
+		public void preUnBind(Context ctx) {
+			recordInvocation("pre unbind 1");
 
-			@Override
-			public void postUnBind(Context ctx) {
-				recordInvocation("post unbind 1");
+		}
 
-			}
+		@Override
+		public void postUnBind(Context ctx) {
+			recordInvocation("post unbind 1");
 
-			@Override
-			public void preUpdate(Context ctx) {
-				recordInvocation("pre update 1");
+		}
 
-			}
+		@Override
+		public void preUpdate(Context ctx) {
+			recordInvocation("pre update 1");
 
-			@Override
-			public void postUpdate(Context ctx) {
-				recordInvocation("post update 1");
+		}
 
-			}
+		@Override
+		public void postUpdate(Context ctx) {
+			recordInvocation("post update 1");
 
-			@Override
-			public void preGetInstance(Context ctx) {
-				recordInvocation("pre getinstance 1");
-			}
+		}
 
-			@Override
-			public void postGetInstance(Context ctx) {
-				recordInvocation("post getinstance 1");
-			}
-		});
+		@Override
+		public void preGetInstance(Context ctx) {
+			recordInvocation("pre getinstance 1");
+		}
 
-		defaultProcessors.add(new BrokerProcessor() {
+		@Override
+		public void postGetInstance(Context ctx) {
+			recordInvocation("post getinstance 1");
+		}
+	};
+	private BrokerProcessor processor2 = new BrokerProcessor() {
 
-			@Override
-			public void preCreate(Context ctx) {
-				recordInvocation("preCreate 2");
-			}
+		@Override
+		public void preCreate(Context ctx) {
+			recordInvocation("preCreate 2");
+		}
 
-			@Override
-			public void preGetLastOperation(Context ctx) { recordInvocation("preGetLastCreateOperation 2"); }
+		@Override
+		public void preGetLastOperation(Context ctx) {
+			recordInvocation("preGetLastCreateOperation 2");
+		}
 
-			@Override
-			public void preBind(Context ctx) {
-				recordInvocation("preBind 2");
-			}
-
-
-			@Override
-			public void postCreate(Context ctx) {
-				recordInvocation("post Create 2");
-			}
-
-			@Override
-			public void postGetLastOperation(Context ctx) { recordInvocation("preGetLastCreateOperation 2"); }
-
-			@Override
-			public void postBind(Context ctx) {
-				recordInvocation("post Bind 2");
-			}
-
-			@Override
-			public void preGetInstance(Context ctx) { recordInvocation("pre getinstance 2"); }
-
-			@Override
-			public void postGetInstance(Context ctx) { recordInvocation("post getinstance 2"); }
-			@Override
-			public void preDelete(Context ctx) {
-				recordInvocation("pre delete 2");
-
-			}
-
-			@Override
-			public void postDelete(Context ctx) {
-				recordInvocation("post delete 2");
-
-			}
-
-			@Override
-			public void preUnBind(Context ctx) {
-				recordInvocation("pre unbind 2");
-
-			}
-
-			@Override
-			public void postUnBind(Context ctx) {
-				recordInvocation("post unbind 2");
-
-			}
-
-			@Override
-			public void preUpdate(Context ctx) {
-				recordInvocation("pre update 2");
-
-			}
-
-			@Override
-			public void postUpdate(Context ctx) {
-				recordInvocation("post update 2");
-
-			}
-
-			@Override
-			public void cleanUp(Context ctx) {
-				recordInvocation("cleanUp 2");
-			}
-
-		});
+		@Override
+		public void preBind(Context ctx) {
+			recordInvocation("preBind 2");
+		}
 
 
-		DefaultBrokerSink sink=new DefaultBrokerSink();
-		chain=new ProcessorChain(defaultProcessors, sink);
-	}
+		@Override
+		public void postCreate(Context ctx) {
+			recordInvocation("post Create 2");
+		}
+
+		@Override
+		public void postGetLastOperation(Context ctx) {
+			recordInvocation("preGetLastCreateOperation 2");
+		}
+
+		@Override
+		public void postBind(Context ctx) {
+			recordInvocation("post Bind 2");
+		}
+
+		@Override
+		public void preGetInstance(Context ctx) {
+			recordInvocation("pre getinstance 2");
+		}
+
+		@Override
+		public void postGetInstance(Context ctx) {
+			recordInvocation("post getinstance 2");
+		}
+
+		@Override
+		public void preDelete(Context ctx) {
+			recordInvocation("pre delete 2");
+
+		}
+
+		@Override
+		public void postDelete(Context ctx) {
+			recordInvocation("post delete 2");
+
+		}
+
+		@Override
+		public void preUnBind(Context ctx) {
+			recordInvocation("pre unbind 2");
+
+		}
+
+		@Override
+		public void postUnBind(Context ctx) {
+			recordInvocation("post unbind 2");
+
+		}
+
+		@Override
+		public void preUpdate(Context ctx) {
+			recordInvocation("pre update 2");
+
+		}
+
+		@Override
+		public void postUpdate(Context ctx) {
+			recordInvocation("post update 2");
+
+		}
+
+		@Override
+		public void cleanUp(Context ctx) {
+			recordInvocation("cleanUp 2");
+		}
+
+	};
 
 	@Test
 	public void testDefaultProcessorsOrder() {
+		//given default processors are added
+		List<BrokerProcessor> defaultProcessors= new ArrayList<>();
+		defaultProcessors.add(processor1);
+		defaultProcessors.add(processor2);
+
+		DefaultBrokerSink sink=new DefaultBrokerSink();
+		ProcessorChain chain=new ProcessorChain(defaultProcessors, null, sink);
+
+
+		//then default order is respected
 		chain.create(new Context());
 
 		List<String> expectedCreateInvocations = Arrays.asList(
@@ -263,6 +275,106 @@ public class ProcessorChainTest {
 			"cleanUp 2",
 			"cleanUp 1");
 		assertThat(invocations).isEqualTo(expectedDeleteInvocations);
+		invocations.clear();
+
+	}
+
+	@Test
+	public void testDeleteSpecificProcessorsOrder() {
+		//given default processors are added
+		List<BrokerProcessor> defaultProcessors= new ArrayList<>();
+		defaultProcessors.add(processor1);
+		defaultProcessors.add(processor2);
+
+		//given delete processors are added using a different order
+		List<BrokerProcessor> deleteProcessors= new ArrayList<>();
+		deleteProcessors.add(processor2);
+		deleteProcessors.add(processor1);
+
+		DefaultBrokerSink sink=new DefaultBrokerSink();
+		ProcessorChain chain=new ProcessorChain(defaultProcessors, deleteProcessors, sink);
+
+
+
+
+		//then the delete specific processors are invoked
+		chain.delete(new Context());
+		List<String> expectedDeleteInvocations = Arrays.asList(
+			"pre delete 2",
+			"pre delete 1",
+			"post delete 1",
+			"post delete 2",
+			"cleanUp 1",
+			"cleanUp 2");
+		assertThat(invocations).isEqualTo(expectedDeleteInvocations);
+		invocations.clear();
+
+		//and the default order is respected for other steps than delete
+		chain.create(new Context());
+		List<String> expectedCreateInvocations = Arrays.asList(
+			"preCreate 1",
+			"preCreate 2",
+			"post Create 2",
+			"post Create 1",
+			"cleanUp 2",
+			"cleanUp 1");
+		assertThat(invocations).isEqualTo(expectedCreateInvocations);
+		invocations.clear();
+
+		chain.getLastOperation(new Context());
+		List<String> expectedLastOperationsInvocations = Arrays.asList(
+			"preGetLastCreateOperation 1",
+			"preGetLastCreateOperation 2",
+			"preGetLastCreateOperation 2",
+			"preGetLastCreateOperation 1",
+			"cleanUp 2",
+			"cleanUp 1");
+		assertThat(invocations).isEqualTo(expectedLastOperationsInvocations);
+		invocations.clear();
+
+
+		chain.bind(new Context());
+		List<String> expectedBindInvocations = Arrays.asList(
+			"preBind 1",
+			"preBind 2",
+			"post Bind 2",
+			"post Bind 1",
+			"cleanUp 2",
+			"cleanUp 1");
+		assertThat(invocations).isEqualTo(expectedBindInvocations);
+		invocations.clear();
+
+		chain.unBind(new Context());
+		List<String> expectedUnbindInvocations = Arrays.asList(
+			"pre unbind 1",
+			"pre unbind 2",
+			"post unbind 2",
+			"post unbind 1",
+			"cleanUp 2",
+			"cleanUp 1");
+		assertThat(invocations).isEqualTo(expectedUnbindInvocations);
+		invocations.clear();
+
+		chain.update(new Context());
+		List<String> expectedUpdateInvocations = Arrays.asList(
+			"pre update 1",
+			"pre update 2",
+			"post update 2",
+			"post update 1",
+			"cleanUp 2",
+			"cleanUp 1");
+		assertThat(invocations).isEqualTo(expectedUpdateInvocations);
+		invocations.clear();
+
+		chain.getInstance(new Context());
+		List<String> expectedGetInstanceInvocations = Arrays.asList(
+			"pre getinstance 1",
+			"pre getinstance 2",
+			"post getinstance 2",
+			"post getinstance 1",
+			"cleanUp 2",
+			"cleanUp 1");
+		assertThat(invocations).isEqualTo(expectedGetInstanceInvocations);
 		invocations.clear();
 
 	}

--- a/cf-ops-automation-broker-framework/src/test/java/com/orange/oss/cloudfoundry/broker/opsautomation/ondemandbroker/processors/ProcessorChainTest.java
+++ b/cf-ops-automation-broker-framework/src/test/java/com/orange/oss/cloudfoundry/broker/opsautomation/ondemandbroker/processors/ProcessorChainTest.java
@@ -1,193 +1,275 @@
 package com.orange.oss.cloudfoundry.broker.opsautomation.ondemandbroker.processors;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 
 public class ProcessorChainTest {
 
 	private static Logger logger=LoggerFactory.getLogger(ProcessorChainTest.class.getName());
 
-	@Test
-	public void testInvocationChain() {
-		List<BrokerProcessor> processors= new ArrayList<>();
-		processors.add(new BrokerProcessor() {
-			
+	private ProcessorChain chain;
+
+	private final ArrayList<String> invocations = new ArrayList<>();
+	@BeforeEach
+	public void setUp() {
+		List<BrokerProcessor> defaultProcessors= new ArrayList<>();
+		defaultProcessors.add(new BrokerProcessor() {
+
 			@Override
 			public void preCreate(Context ctx) {
-				logger.info("preCreate 1");
-			}
-			
-			@Override
-			public void preBind(Context ctx) {
-				logger.info("preBind 1");
+				recordInvocation("preCreate 1");
 			}
 
 			@Override
-			public void preGetLastOperation(Context ctx) { logger.info("preGetLastCreateOperation 1"); }
+			public void preBind(Context ctx) {
+				recordInvocation("preBind 1");
+			}
+
+			@Override
+			public void preGetLastOperation(Context ctx) { recordInvocation("preGetLastCreateOperation 1"); }
 
 			@Override
 			public void postCreate(Context ctx) {
-				logger.info("post Create 1");
+				recordInvocation("post Create 1");
 			}
 
 			@Override
-			public void postGetLastOperation(Context ctx) { logger.info("preGetLastCreateOperation 1"); }
+			public void postGetLastOperation(Context ctx) { recordInvocation("preGetLastCreateOperation 1"); }
 
 			@Override
 			public void postBind(Context ctx) {
-				logger.info("post Bind 1");
+				recordInvocation("post Bind 1");
 			}
 
 			@Override
 			public void cleanUp(Context ctx) {
-				logger.info("cleanUp 1");
+				recordInvocation("cleanUp 1");
 			}
 
 			@Override
 			public void preDelete(Context ctx) {
-				logger.info("pre delete 1");
-				
+				recordInvocation("pre delete 1");
+
 			}
 
 			@Override
 			public void postDelete(Context ctx) {
-				logger.info("post delete 1");
-				
+				recordInvocation("post delete 1");
+
 			}
 
 			@Override
 			public void preUnBind(Context ctx) {
-				logger.info("post unbind 1");
-				
+				recordInvocation("pre unbind 1");
+
 			}
 
 			@Override
 			public void postUnBind(Context ctx) {
-				logger.info("post unbind 1");
-				
+				recordInvocation("post unbind 1");
+
 			}
 
 			@Override
 			public void preUpdate(Context ctx) {
-				logger.info("pre update 1");
+				recordInvocation("pre update 1");
 
 			}
 
 			@Override
 			public void postUpdate(Context ctx) {
-				logger.info("post update 1");
+				recordInvocation("post update 1");
 
 			}
 
 			@Override
 			public void preGetInstance(Context ctx) {
-				logger.info("pre getinstance 1");
+				recordInvocation("pre getinstance 1");
 			}
 
 			@Override
 			public void postGetInstance(Context ctx) {
-				logger.info("post getinstance 1");
+				recordInvocation("post getinstance 1");
 			}
 		});
-		
-		processors.add(new BrokerProcessor() {
-			
+
+		defaultProcessors.add(new BrokerProcessor() {
+
 			@Override
 			public void preCreate(Context ctx) {
-				logger.info("preCreate 2");
+				recordInvocation("preCreate 2");
 			}
 
 			@Override
-			public void preGetLastOperation(Context ctx) { logger.info("preGetLastCreateOperation 2"); }
+			public void preGetLastOperation(Context ctx) { recordInvocation("preGetLastCreateOperation 2"); }
 
 			@Override
 			public void preBind(Context ctx) {
-				logger.info("preBind 2");
+				recordInvocation("preBind 2");
 			}
 
 
 			@Override
 			public void postCreate(Context ctx) {
-				logger.info("post Create 2");
+				recordInvocation("post Create 2");
 			}
 
 			@Override
-			public void postGetLastOperation(Context ctx) { logger.info("preGetLastCreateOperation 2"); }
+			public void postGetLastOperation(Context ctx) { recordInvocation("preGetLastCreateOperation 2"); }
 
 			@Override
 			public void postBind(Context ctx) {
-				logger.info("post Bind 2");
+				recordInvocation("post Bind 2");
 			}
 
 			@Override
-			public void preGetInstance(Context ctx) { logger.info("pre getinstance 2"); }
+			public void preGetInstance(Context ctx) { recordInvocation("pre getinstance 2"); }
 
 			@Override
-			public void postGetInstance(Context ctx) { logger.info("post getinstance 2"); }
+			public void postGetInstance(Context ctx) { recordInvocation("post getinstance 2"); }
 			@Override
 			public void preDelete(Context ctx) {
-				logger.info("pre delete 2");
-				
+				recordInvocation("pre delete 2");
+
 			}
 
 			@Override
 			public void postDelete(Context ctx) {
-				logger.info("post delete 2");
-				
+				recordInvocation("post delete 2");
+
 			}
 
 			@Override
 			public void preUnBind(Context ctx) {
-				logger.info("pre unbind 2");
-				
+				recordInvocation("pre unbind 2");
+
 			}
 
 			@Override
 			public void postUnBind(Context ctx) {
-				logger.info("post unbind 2");
-				
+				recordInvocation("post unbind 2");
+
 			}
 
 			@Override
 			public void preUpdate(Context ctx) {
-				logger.info("pre update 2");
+				recordInvocation("pre update 2");
 
 			}
 
 			@Override
 			public void postUpdate(Context ctx) {
-				logger.info("pre update 2");
+				recordInvocation("post update 2");
 
 			}
 
 			@Override
 			public void cleanUp(Context ctx) {
-				logger.info("cleanUp 2");
+				recordInvocation("cleanUp 2");
 			}
 
 		});
 
-		
-		DefaultBrokerSink sink=new DefaultBrokerSink();
-		ProcessorChain chain=new ProcessorChain(processors, sink);
-		Context ctx=new Context();
-		chain.create(ctx);
 
-		Context ctx1 =new Context();
-		chain.getLastOperation(ctx1);
-		chain.bind(new Context());
-		chain.unBind(new Context());
-		chain.delete(new Context());
-	
-	
-		
-		
-		
+		DefaultBrokerSink sink=new DefaultBrokerSink();
+		chain=new ProcessorChain(defaultProcessors, sink);
 	}
-	
+
+	@Test
+	public void testDefaultProcessorsOrder() {
+		chain.create(new Context());
+
+		List<String> expectedCreateInvocations = Arrays.asList(
+			"preCreate 1",
+			"preCreate 2",
+			"post Create 2",
+			"post Create 1",
+			"cleanUp 2",
+			"cleanUp 1");
+		assertThat(invocations).isEqualTo(expectedCreateInvocations);
+		invocations.clear();
+
+		chain.getLastOperation(new Context());
+		List<String> expectedLastOperationsInvocations = Arrays.asList(
+			"preGetLastCreateOperation 1",
+			"preGetLastCreateOperation 2",
+			"preGetLastCreateOperation 2",
+			"preGetLastCreateOperation 1",
+			"cleanUp 2",
+			"cleanUp 1");
+		assertThat(invocations).isEqualTo(expectedLastOperationsInvocations);
+		invocations.clear();
+
+
+		chain.bind(new Context());
+		List<String> expectedBindInvocations = Arrays.asList(
+			"preBind 1",
+			"preBind 2",
+			"post Bind 2",
+			"post Bind 1",
+			"cleanUp 2",
+			"cleanUp 1");
+		assertThat(invocations).isEqualTo(expectedBindInvocations);
+		invocations.clear();
+
+		chain.unBind(new Context());
+		List<String> expectedUnbindInvocations = Arrays.asList(
+			"pre unbind 1",
+			"pre unbind 2",
+			"post unbind 2",
+			"post unbind 1",
+			"cleanUp 2",
+			"cleanUp 1");
+		assertThat(invocations).isEqualTo(expectedUnbindInvocations);
+		invocations.clear();
+
+		chain.update(new Context());
+		List<String> expectedUpdateInvocations = Arrays.asList(
+			"pre update 1",
+			"pre update 2",
+			"post update 2",
+			"post update 1",
+			"cleanUp 2",
+			"cleanUp 1");
+		assertThat(invocations).isEqualTo(expectedUpdateInvocations);
+		invocations.clear();
+
+		chain.getInstance(new Context());
+		List<String> expectedGetInstanceInvocations = Arrays.asList(
+			"pre getinstance 1",
+			"pre getinstance 2",
+			"post getinstance 2",
+			"post getinstance 1",
+			"cleanUp 2",
+			"cleanUp 1");
+		assertThat(invocations).isEqualTo(expectedGetInstanceInvocations);
+		invocations.clear();
+
+		chain.delete(new Context());
+		List<String> expectedDeleteInvocations = Arrays.asList(
+			"pre delete 1",
+			"pre delete 2",
+			"post delete 2",
+			"post delete 1",
+			"cleanUp 2",
+			"cleanUp 1");
+		assertThat(invocations).isEqualTo(expectedDeleteInvocations);
+		invocations.clear();
+
+	}
+
+	private void recordInvocation(String processorStep) {
+		logger.info(processorStep);
+		invocations.add(processorStep);
+	}
+
 }


### PR DESCRIPTION
Refine traces for help diagnostic #398 

- RunException refined to include failed status
- info logs with push errors replaced with error logs so that common broker scripts displays them in smoke tests assertions.
- error logs now use pretty print for push and rebase results

Fixes https://github.com/orange-cloudfoundry/cf-ops-automation-broker/issues/399