### PR TITLE
Refine input validaton for OSB context annotations + harden defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ This is designed to support undeletes by operators until they explicitly approve
 
 Some brokers with highly sensitive data (e.g. implementing data erasure) should prefer to not opt-in for this flag, as this could increase risk of data recovery after the service deprovision phase. 
 
+### Disable input validation as a transient workaround
+
+Coab strives to perform strict fail-fast input validation to prevent security-related injections in paas-templates.
+
+When the input validation is too restrictive and blocks legitimate use-case, it is possible to transiently disable input validation through setting the `deployment.coabVarsInputValidationDisabled` property to `true` (default is `false`)
+
 ### Troubleshooting COAB
 
 #### Spring boot debug mode

--- a/cf-ops-automation-bosh-broker/src/main/java/com/orange/oss/cloudfoundry/broker/opsautomation/ondemandbroker/sample/BoshBrokerApplication.java
+++ b/cf-ops-automation-bosh-broker/src/main/java/com/orange/oss/cloudfoundry/broker/opsautomation/ondemandbroker/sample/BoshBrokerApplication.java
@@ -112,24 +112,32 @@ public class BoshBrokerApplication {
 
     @Bean
     public SecretsGenerator secretsGenerator(
-            DeploymentProperties deploymentProperties) {
+        DeploymentProperties deploymentProperties,
+        VarsFilesYmlFormatter varsFilesYmlFormatter) {
         return new SecretsGenerator(
                 deploymentProperties.getRootDeployment(),
                 deploymentProperties.getModelDeployment(),
                 deploymentProperties.getModelDeploymentShortAlias(),
                 deploymentProperties.getModelDeploymentSeparator(),
-                new VarsFilesYmlFormatter()  //externalize if needed
+            varsFilesYmlFormatter
         );
     }
 
     @Bean
-    public TemplatesGenerator templatesGenerator(DeploymentProperties deploymentProperties) {
+    public VarsFilesYmlFormatter varsFilesYmlFormatter(DeploymentProperties deploymentProperties) {
+        return new VarsFilesYmlFormatter(deploymentProperties.isCoabVarsInputValidationDisabled());
+    }
+
+    @Bean
+    public TemplatesGenerator templatesGenerator(
+        DeploymentProperties deploymentProperties,
+        VarsFilesYmlFormatter varsFilesYmlFormatter) {
         return new TemplatesGenerator(
                 deploymentProperties.getRootDeployment(),
                 deploymentProperties.getModelDeployment(),
                 deploymentProperties.getModelDeploymentShortAlias(),
                 deploymentProperties.getModelDeploymentSeparator(),
-                new VarsFilesYmlFormatter() //externalize if needed
+            varsFilesYmlFormatter
         );
     }
 

--- a/cf-ops-automation-broker-core/src/main/java/com/orange/oss/cloudfoundry/broker/opsautomation/ondemandbroker/pipeline/CoabVarsFileDto.java
+++ b/cf-ops-automation-broker-core/src/main/java/com/orange/oss/cloudfoundry/broker/opsautomation/ondemandbroker/pipeline/CoabVarsFileDto.java
@@ -27,21 +27,29 @@ public class CoabVarsFileDto {
      * \d 	A digit: [0-9]
      * \w 	A word character: [a-zA-Z_0-9]
      */
-    public static final String WHITE_LISTED_PATTERN = "[\\w\\d _./-]*";
-    public static final String WHITE_LISTED_MESSAGE = "must only contain a-Z, 0-9, space, _, dot, slash and - chars";
+    public static final String WHITE_LISTED_PATTERN = "[\\w\\d _.-]*";
+    public static final String WHITE_LISTED_MESSAGE = "must only contain a-Z, 0-9, space, _, dot, and - chars";
 
     /**
      * Name of the maps key (and subkeys) which should be applied relaxed patterns
-     * This is designed to support K8S service catalog annotations which contain specific chars that we ignore
+     * This is designed to support JSON Serialized fields that COA models ignore
      */
-    public static final List<String> RELAXED_KEY_NAMES= asList("brokered_service_originating_identity_username", "brokered_service_originating_identity_groups");
+    public static final List<String> RELAXED_KEY_NAMES= asList(
+        "brokered_service_api_info_location", //contain forward slashes as in api.redacted-domain.org/v2/info
+        //K8S service catalog annotations which contain JSON serialized chars that we accept
+        "brokered_service_originating_identity_username",
+        "brokered_service_originating_identity_groups",
+        //CF annotations sent as Json serialized
+        "brokered_service_context_organization_annotations",
+        "brokered_service_context_space_annotations",
+        "brokered_service_context_instance_annotations");
     /**
      * \d 	A digit: [0-9]
      * \w 	A word character: [a-zA-Z_0-9]
      */
-    public static final String RELAXED_WHITE_LISTED_PATTERN = "[\\w\\d _.,/\\-:\\[\\]\"]*";
+    public static final String RELAXED_WHITE_LISTED_PATTERN = "[\\w\\d _.,/\\-:\\[\\]\"{}]*";
     public static final String RELAXED_WHITE_LISTED_MESSAGE = "must only contain a-Z, 0-9, space, _ (underscore), . (dot), , " +
-        "(comma), : (column), left and right brackets ([]), quote (\"), slash (/) and dash (-) chars";
+        "(comma), : (column), left and right brackets ([]), braces ({}=quote (\"), slash (/) and dash (-) chars";
 
 
     /**

--- a/cf-ops-automation-broker-core/src/main/java/com/orange/oss/cloudfoundry/broker/opsautomation/ondemandbroker/pipeline/DeploymentProperties.java
+++ b/cf-ops-automation-broker-core/src/main/java/com/orange/oss/cloudfoundry/broker/opsautomation/ondemandbroker/pipeline/DeploymentProperties.java
@@ -48,6 +48,12 @@ public class DeploymentProperties {
      */
     private boolean serviceInstanceReadOnlyMode= false;
 
+    /**
+     * Emergency support for turning off input validation when it is observed to perform false positive.
+     * Once a coab release fixes the false positive, then this flag should be turned off again.
+     */
+    private boolean coabVarsInputValidationDisabled= false;
+
     public static final String DEFAULT_READ_ONLY_MESSAGE = "Maintenance mode in progress. Service instance operations " +
         "(create-service, update-service, delete-service) are not available. Service binding operations are available" +
         " (bind-service unbind-service)";
@@ -114,6 +120,14 @@ public class DeploymentProperties {
         if (serviceInstanceReadOnlyMessage != null && ! serviceInstanceReadOnlyMessage.isEmpty()) {
             this.serviceInstanceReadOnlyMessage = serviceInstanceReadOnlyMessage;
         }
+    }
+
+    public boolean isCoabVarsInputValidationDisabled() {
+        return coabVarsInputValidationDisabled;
+    }
+
+    public void setCoabVarsInputValidationDisabled(boolean coabVarsInputValidationDisabled) {
+        this.coabVarsInputValidationDisabled = coabVarsInputValidationDisabled;
     }
 
 }

--- a/cf-ops-automation-broker-core/src/test/java/com/orange/oss/cloudfoundry/broker/opsautomation/ondemandbroker/pipeline/BoshDeploymentManifestDTOTest.java
+++ b/cf-ops-automation-broker-core/src/test/java/com/orange/oss/cloudfoundry/broker/opsautomation/ondemandbroker/pipeline/BoshDeploymentManifestDTOTest.java
@@ -13,7 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class BoshDeploymentManifestDTOTest {
 
-	VarsFilesYmlFormatter formatter = new VarsFilesYmlFormatter();
+	VarsFilesYmlFormatter formatter = new VarsFilesYmlFormatter(false);
 
 	@Test
 	void parsesBoshManifestWithCompletionTracker() throws IOException, URISyntaxException {
@@ -34,7 +34,7 @@ class BoshDeploymentManifestDTOTest {
 		//Given a bosh manifest is ready (in src/test/resources)
 
 		//When parsing it
-		VarsFilesYmlFormatter formatter = new VarsFilesYmlFormatter();
+		VarsFilesYmlFormatter formatter = new VarsFilesYmlFormatter(false);
 		Path pathToBoshManifestFile = getResourcePath("/coab-bosh-manifests/manifest-without-completion-marker.yml");
 		CoabVarsFileDto coabVarsFileDto = formatter.parseFromBoshManifestYml(pathToBoshManifestFile);
 

--- a/cf-ops-automation-broker-core/src/test/java/com/orange/oss/cloudfoundry/broker/opsautomation/ondemandbroker/pipeline/SecretsGeneratorTest.java
+++ b/cf-ops-automation-broker-core/src/test/java/com/orange/oss/cloudfoundry/broker/opsautomation/ondemandbroker/pipeline/SecretsGeneratorTest.java
@@ -39,7 +39,7 @@ public class SecretsGeneratorTest extends StructureGeneratorImplTest{
         this.secretsGenerator = new SecretsGenerator(this.deploymentProperties.getRootDeployment(),
                                     this.deploymentProperties.getModelDeployment(),
                 this.deploymentProperties.getModelDeploymentShortAlias(),
-                this.deploymentProperties.getModelDeploymentSeparator(), new VarsFilesYmlFormatter());
+                this.deploymentProperties.getModelDeploymentSeparator(), new VarsFilesYmlFormatter(false));
     }
 
     @Test
@@ -158,7 +158,7 @@ public class SecretsGeneratorTest extends StructureGeneratorImplTest{
         secretsGenerator = new SecretsGenerator("coab-depls",
                 "cassandravarsops",
                 "m",
-                "_", new VarsFilesYmlFormatter());
+                "_", new VarsFilesYmlFormatter(false));
 
 
         //When
@@ -174,7 +174,7 @@ public class SecretsGeneratorTest extends StructureGeneratorImplTest{
     public void check_that_coa_produced_manifest_is_parsed_into_vars_dto() throws IOException {
         //Given a DeploymentProperties for cassandra with "m" prefix (e.g. mongo)
         //Given a secrets generator
-        VarsFilesYmlFormatter varsFilesYmlFormatter = new VarsFilesYmlFormatter();
+        VarsFilesYmlFormatter varsFilesYmlFormatter = new VarsFilesYmlFormatter(false);
         secretsGenerator = new SecretsGenerator("coab-depls",
                 "cassandravarsops",
                 "m",

--- a/cf-ops-automation-broker-core/src/test/java/com/orange/oss/cloudfoundry/broker/opsautomation/ondemandbroker/pipeline/TemplatesGeneratorTest.java
+++ b/cf-ops-automation-broker-core/src/test/java/com/orange/oss/cloudfoundry/broker/opsautomation/ondemandbroker/pipeline/TemplatesGeneratorTest.java
@@ -37,7 +37,7 @@ public class TemplatesGeneratorTest extends StructureGeneratorImplTest{
                 this.deploymentProperties.getModelDeployment(),
                 "c",
                 "_",
-                new VarsFilesYmlFormatter());
+                new VarsFilesYmlFormatter(false));
         //Init sample deployments
         this.initReferenceModelStructures();
     }
@@ -99,7 +99,7 @@ public class TemplatesGeneratorTest extends StructureGeneratorImplTest{
                 "areferencemodel",
                 "r",
                 "_",
-                new VarsFilesYmlFormatter());
+                new VarsFilesYmlFormatter(false));
 
         //When
         templatesGenerator.checkPrerequisites(tempDir.toPath());
@@ -264,7 +264,7 @@ public class TemplatesGeneratorTest extends StructureGeneratorImplTest{
                 "areferencemodel",
                 "r",
                 "_",
-                new VarsFilesYmlFormatter());
+                new VarsFilesYmlFormatter(false));
 
         //Given a minimal deployment structure
         Structure deploymentStructure = new Structure.StructureBuilder(tempDir.toPath())
@@ -320,7 +320,7 @@ public class TemplatesGeneratorTest extends StructureGeneratorImplTest{
                 modelDeployment,
                 modelDeploymentShortAlias,
                 modelDeploymentSeparator,
-                new VarsFilesYmlFormatter());
+                new VarsFilesYmlFormatter(false));
 
         //When
         templatesGenerator.checkPrerequisites(paasTemplatePath);
@@ -368,7 +368,7 @@ public class TemplatesGeneratorTest extends StructureGeneratorImplTest{
                 "01-cf-mysql-extended",
                 "t",
                 "_",
-                new VarsFilesYmlFormatter());
+                new VarsFilesYmlFormatter(false));
 
         //When
         templatesGenerator.checkPrerequisites(workDir);

--- a/cf-ops-automation-broker-core/src/test/java/com/orange/oss/cloudfoundry/broker/opsautomation/ondemandbroker/pipeline/VarsFilesYmlFormatterTest.java
+++ b/cf-ops-automation-broker-core/src/test/java/com/orange/oss/cloudfoundry/broker/opsautomation/ondemandbroker/pipeline/VarsFilesYmlFormatterTest.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.orange.oss.cloudfoundry.broker.opsautomation.ondemandbroker.UserFacingRuntimeException;
 import org.apache.commons.lang.RandomStringUtils;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -23,9 +24,14 @@ import static org.assertj.core.api.Fail.fail;
 
 public class VarsFilesYmlFormatterTest {
 
-    VarsFilesYmlFormatter formatter = new VarsFilesYmlFormatter();
+    VarsFilesYmlFormatter formatter;
 
     private static Logger logger = LoggerFactory.getLogger(VarsFilesYmlFormatterTest.class.getName());
+
+    @BeforeEach
+    void setUp() {
+        formatter = new VarsFilesYmlFormatter(false);
+    }
 
     @Test
     public void handles_default_empty_osb_context_annotations_in_osb_cmdb() throws IOException {
@@ -127,6 +133,16 @@ public class VarsFilesYmlFormatterTest {
         coabVarsFileDtoWithPreviousValueWithNoPlan.previous_values.plan_id=null;
         coabVarsFileDtoWithPreviousValueWithNoPlan.previous_values.maintenanceInfo=OsbBuilderHelper.anInitialMaintenanceInfo();
         assertDtoSerializesAndDeserializesWithoutError(coabVarsFileDtoWithPreviousValueWithNoPlan);
+    }
+
+    @Test
+    public void accepts_invalid_patterns_when_input_validation_disabled() throws IOException {
+        //given a formatter with input validation disabled
+        formatter = new VarsFilesYmlFormatter(true);
+
+        //when invalid input is received
+        //then it is accepted
+        assertParamValueAccepted("$(a_malicious_shell_command_to_inject_in_bosh_templates)");
     }
 
     @Test

--- a/cf-ops-automation-broker-core/src/test/java/com/orange/oss/cloudfoundry/broker/opsautomation/ondemandbroker/pipeline/VarsFilesYmlFormatterTest.java
+++ b/cf-ops-automation-broker-core/src/test/java/com/orange/oss/cloudfoundry/broker/opsautomation/ondemandbroker/pipeline/VarsFilesYmlFormatterTest.java
@@ -2,6 +2,8 @@ package com.orange.oss.cloudfoundry.broker.opsautomation.ondemandbroker.pipeline
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -26,8 +28,39 @@ public class VarsFilesYmlFormatterTest {
     private static Logger logger = LoggerFactory.getLogger(VarsFilesYmlFormatterTest.class.getName());
 
     @Test
-    public void handles_whitelisted_osb_cmdb_k8s_svcat_patterns() throws IOException {
+    public void handles_default_empty_osb_context_annotations_in_osb_cmdb() throws IOException {
         //cmdbJson_k8s_profile with special characters accepted
+        assertParamJsonValueAccepted("{\n" +
+            "        \"annotations\": {\n" +
+            "          \"brokered_service_client_name\": \"osb-cmdb-backend-services-org-client-0\",\n" +
+            "          \"brokered_service_context_organization_annotations\": \"{}\",\n" +
+            "          \"brokered_service_context_spaceName\": \"smoke-tests\",\n" +
+            "          \"brokered_service_context_space_annotations\": \"{}\",\n" +
+            "          \"brokered_service_context_organizationName\": \"osb-cmdb-brokered-services-org-client-0\",\n" +
+            "          \"brokered_service_context_instance_annotations\": \"{}\",\n" +
+            "          \"brokered_service_api_info_location\": \"api.redacted-domain.org/v2/info\",\n" +
+            "          \"brokered_service_context_instanceName\": \"gberche-osb-cmdb-0\"\n" +
+            "        },\n" +
+            "        \"labels\": {\n" +
+            "          \"brokered_service_instance_guid\": \"0ff910ce-d1e8-437a-a40c-0a93cc27c9d7\",\n" +
+            "          \"brokered_service_context_organization_guid\": \"c2169b61-9360-4d67-968c-575f3a10edf5\",\n" +
+            "          \"brokered_service_originating_identity_user_id\": \"0fff310e-552c-4014-9943-d7acd9875865\",\n" +
+            "          \"brokered_service_context_space_guid\": \"1a603476-a3a1-4c32-8021-d2a7b9b7c6b4\"\n" +
+            "        }\n" +
+            "      }");
+
+        //white listed key with invalid character
+        assertParamJsonValueRejected(
+            "{\n" +
+                "  \"brokered_service_originating_identity_groups\": {\n" +
+                "    \"a-malicious-sub-key-with-variable\": \"$VARIABLE\" \n" +
+                "  }\n" +
+                "}");
+    }
+
+    @Test
+    public void handles_whitelisted_osb_cmdb_patterns() throws IOException {
+        //cmdbJson_k8s_profile with special characters accepted to support JSON encoded field
         assertParamJsonValueAccepted("{\n" +
             "  \"annotations\": {\n" +
             "    \"brokered_service_originating_identity_groups\": \"[\\\"system:serviceaccounts\\\",\\\"system:serviceaccounts:catalog\\\",\\\"system:authenticated\\\"]\",\n" +
@@ -39,6 +72,23 @@ public class VarsFilesYmlFormatterTest {
             "    \"brokered_service_originating_identity_uid\": \"d624ecee-99b0-4fd1-974f-0428bd9bc503\",\n" +
             "    \"brokered_service_context_instance_name\": \"poctv-mongodb-dedicated\",\n" +
             "    \"brokered_service_context_namespace\": \"fmt-private-mkaasq1\"\n" +
+            "  }\n" +
+            "}");
+
+        //cmdbJson_cf_profile with JSON encoded annotations accepted in relaxed fields
+        assertParamJsonValueAccepted("{\n" +
+            "  \"annotations\": {\n" +
+            "    \"brokered_service_context_organization_annotations\": \"{\\\"domain.com/org-key1\\\":\\\"org-value1\\\",\\\"orange.com/overrideable-key\\\":\\\"org-value2\\\"}\",\n" +
+            "    \"brokered_service_context_space_annotations\": \"{\\\"domain.com/space-key1\\\":\\\"space-value1\\\",\\\"orange.com/overrideable-key\\\":\\\"space-value2\\\"}\",\n" +
+            "    \"brokered_service_context_instance_annotations\": \"{\\\"domain.com/instance-key1\\\":\\\"instance-value1\\\",\\\"orange.com/overrideable-key\\\":\\\"instance-value2\\\"}\"\n" +
+            "  },\n" +
+            "  \"labels\": {\n" +
+            "    \"brokered_service_context_clusterid\": \"ed99367d-2998-46c6-b700-59187141faf9\",\n" +
+            "    \"brokered_service_instance_guid\": \"3c2def14-7073-4398-a901-bc4929b765aa\",\n" +
+            "    \"brokered_service_originating_identity_uid\": \"d624ecee-99b0-4fd1-974f-0428bd9bc503\",\n" +
+            "    \"brokered_service_context_instance_name\": \"poctv-mongodb-dedicated\",\n" +
+            "    \"brokered_service_context_namespace\": \"fmt-private-mkaasq1\",\n" +
+            "    \"brokered_service_context_orange_overrideable-key\": \"instance-value2\"" +
             "  }\n" +
             "}");
 
@@ -81,9 +131,6 @@ public class VarsFilesYmlFormatterTest {
 
     @Test
     public void accepts_valid_patterns() throws IOException {
-        assertParamValueAccepted("a/path");
-        assertParamValueAccepted("../../etc/password");
-        assertParamValueAccepted("api.mycf.org/v2/info");
         assertParamValueAccepted("a string with spaces");
         assertParamValueAccepted("10mb");
         assertParamValueAccepted("a deployment model cassandravarsops_aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa0");
@@ -112,15 +159,24 @@ public class VarsFilesYmlFormatterTest {
     }
     @Test
     public void rejects_invalid_patterns() throws IOException {
-        assertDeploymentNameAndParamValueRejected("`a_malicious_shell_command_to_inject_in_bosh_templates`");
-        assertDeploymentNameAndParamValueRejected("``");
-        assertDeploymentNameAndParamValueRejected("$(a_malicious_shell_command_to_inject_in_bosh_templates)");
-        assertDeploymentNameAndParamValueRejected("$()");
-        assertDeploymentNameAndParamValueRejected("(("); //credhub interpolation
-        assertDeploymentNameAndParamValueRejected("(( a/string ))");
-        assertDeploymentNameAndParamValueRejected("))");
-        assertDeploymentNameAndParamValueRejected("?"); //other unknown chars
-        assertDeploymentNameAndParamValueRejected("&"); //YML references
+        assertInputRejectedFromFieldsUsedByCoabModels("`a_malicious_shell_command_to_inject_in_bosh_templates`");
+        assertInputRejectedFromFieldsUsedByCoabModels("``");
+        assertInputRejectedFromFieldsUsedByCoabModels("$(a_malicious_shell_command_to_inject_in_bosh_templates)");
+        assertInputRejectedFromFieldsUsedByCoabModels("$()");
+        assertInputRejectedFromFieldsUsedByCoabModels("(("); //credhub interpolation
+        assertInputRejectedFromFieldsUsedByCoabModels("(( a/string ))");
+        assertInputRejectedFromFieldsUsedByCoabModels("))");
+        assertInputRejectedFromFieldsUsedByCoabModels("?"); //other unknown chars
+        assertInputRejectedFromFieldsUsedByCoabModels("&"); //YML references
+        assertInputRejectedFromFieldsUsedByCoabModels("\n"); //YML new lines
+        assertInputRejectedFromFieldsUsedByCoabModels("\r"); //YML new lines
+        //<script>alert('XSS')</script>
+        assertInputRejectedFromFieldsUsedByCoabModels("<");
+        assertInputRejectedFromFieldsUsedByCoabModels("/");
+        assertInputRejectedFromFieldsUsedByCoabModels(">");
+        assertInputRejectedFromFieldsUsedByCoabModels("'");
+        assertInputRejectedFromFieldsUsedByCoabModels("(");
+        assertInputRejectedFromFieldsUsedByCoabModels(")");
         assertTooLongContentIsRejected(
             RandomStringUtils.randomAlphabetic(VarsFilesYmlFormatter.MAX_SERIALIZED_SIZE + 1));
 
@@ -178,10 +234,15 @@ public class VarsFilesYmlFormatterTest {
         }
     }
 
-    protected void assertDeploymentNameAndParamValueRejected(String paramValue) throws JsonProcessingException {
+    protected void assertInputRejectedFromFieldsUsedByCoabModels(String paramValue) throws JsonProcessingException {
         CoabVarsFileDto coabVarsFileDto = aTypicalUserProvisionningRequest();
         coabVarsFileDto.deployment_name = paramValue;
+        Map<String, Object> osbCmdbMap = new HashMap<>();
+        osbCmdbMap.put("brokered_service_instance_guid", paramValue);
+        osbCmdbMap.put("brokered_service_context_orange_app_code", paramValue);
+        coabVarsFileDto.parameters.put("x-osb-cmdb",osbCmdbMap);
         coabVarsFileDto.parameters.put("aparam", paramValue);
+        coabVarsFileDto.parameters.put("a_nested_param", Collections.singletonMap("a_key", paramValue));
         //noinspection EmptyCatchBlock
         try {
             formatter.formatAsYml(coabVarsFileDto);
@@ -189,7 +250,10 @@ public class VarsFilesYmlFormatterTest {
             fail("expected " + paramValue + "to be rejected");
         } catch (UserFacingRuntimeException e) {
             assertThat(e.getMessage()).contains("deployment_name");
+            assertThat(e.getMessage()).contains("brokered_service_instance_guid");
+            assertThat(e.getMessage()).contains("brokered_service_context_orange_app_code");
             assertThat(e.getMessage()).contains("aparam");
+            assertThat(e.getMessage()).contains("a_key");
         }
     }
 


### PR DESCRIPTION
Some coab-vars.yaml keys which should not be used in models (those with JSON serialized content) are now white listed

* [x] Hardened default accepted characterset in other fields used in models  (e.g. deployment_name or + x-osb-cmdb.brokered_service_instance_guid) and associated refined assertions: now rejects forward slash

Fixes https://github.com/orange-cloudfoundry/cf-ops-automation-broker/issues/404
* [x] add `deployment.coabVarsInputValidationDisabled` property to transiently disable input validation as a hot fix in production