### PR TITLE
Git pooling now cleans working dir

### DIFF
--- a/cf-ops-automation-broker-core/src/main/java/com/orange/oss/cloudfoundry/broker/opsautomation/ondemandbroker/git/SimpleGitManager.java
+++ b/cf-ops-automation-broker-core/src/main/java/com/orange/oss/cloudfoundry/broker/opsautomation/ondemandbroker/git/SimpleGitManager.java
@@ -144,12 +144,15 @@ public class SimpleGitManager implements GitManager {
             fetchCommand.call();
             logger.info(prefixLog("resetting from " + resetRef));
             resetCommand.call();
+            //Clean the working dir from unstaged files (e.g. input validation fails
+            //OSB request before reaching GitProcessor
+            Set<String> cleanedPath = git.clean().call();
+            logger.info(prefixLog("cleaned working dir paths: " + cleanedPath));
         } catch (Exception e) {
             logger.error(prefixLog("caught ") + e + " while fetching & resetting branch: " + remoteBranch, e);
             throw new RuntimeException(e);
         }
-
-    }
+	}
 
     String getRepoWorkDirPrefix(String repoAliasName) {
         return repoAliasName.replaceAll("[^a-zA-Z0-9]", "-") + "clone-";


### PR DESCRIPTION
Fixes #409

Analysis of performance impact using logs in orange labs environment. Cleaning on secret and templates repo take 30 ms for secret repo and 215 ms for templates repo.

```
   2021-07-23T10:23:07.51+0200 [APP/PROC/WEB/0] OUT 2021-07-23 08:23:07.512  INFO 9 --- [nio-8080-exec-3] c.o.o.c.b.o.o.git.SimpleGitManager       : [paas-secrets.] cleaning working dir...
   2021-07-23T10:23:07.54+0200 [APP/PROC/WEB/0] OUT 2021-07-23 08:23:07.542  INFO 9 --- [nio-8080-exec-3] c.o.o.c.b.o.o.git.SimpleGitManager       : [paas-secrets.] cleaned working dir paths: []
   2021-07-23T10:23:07.54+0200 [APP/PROC/WEB/0] OUT 2021-07-23 08:23:07.543  INFO 9 --- [nio-8080-exec-3] c.o.o.c.b.o.o.git.PooledGitRepoFactory   : Validating pooled git repo before reusing it
   2021-07-23T10:23:07.54+0200 [APP/PROC/WEB/0] OUT 2021-07-23 08:23:07.543 DEBUG 9 --- [nio-8080-exec-3] c.o.o.c.b.o.o.git.RetrierGitManager      : fetch attempt #0
   2021-07-23T10:23:07.54+0200 [APP/PROC/WEB/0] OUT 2021-07-23 08:23:07.544  INFO 9 --- [nio-8080-exec-3] c.o.o.c.b.o.o.git.SimpleGitManager       : [paas-templates.] fetching from +refs/heads/feature-coabdepls-noop-serviceinstances:refs/remotes/origin/feature-coabdepls-noop-serviceinstances
   2021-07-23T10:23:08.04+0200 [APP/PROC/WEB/0] OUT 2021-07-23 08:23:08.044  INFO 9 --- [nio-8080-exec-3] c.o.o.c.b.o.o.git.SimpleGitManager       : [paas-templates.] resetting from origin/feature-coabdepls-noop-serviceinstances
   2021-07-23T10:23:08.27+0200 [APP/PROC/WEB/0] OUT 2021-07-23 08:23:08.274  INFO 9 --- [nio-8080-exec-3] c.o.o.c.b.o.o.git.SimpleGitManager       : [paas-templates.] cleaning working dir...
   2021-07-23T10:23:08.48+0200 [APP/PROC/WEB/0] OUT 2021-07-23 08:23:08.489  INFO 9 --- [nio-8080-exec-3] c.o.o.c.b.o.o.git.SimpleGitManager       : [paas-templates.] cleaned working dir paths: []
```