### PR TITLE
Fix missing response code mapping for 410 code

### DIFF
--- a/cf-ops-automation-bosh-broker/src/test/resources/mappings/v2_service_instances_bind_error_response.json
+++ b/cf-ops-automation-bosh-broker/src/test/resources/mappings/v2_service_instances_bind_error_response.json
@@ -1,0 +1,28 @@
+{
+  "id" : "11111111-2222-3333-4444-555555555555",
+  "name" : "v2_service_instances_111_service_bindings_333",
+  "request" : {
+    "url" : "/v2/service_instances/111/service_bindings/333?accepts_incomplete=false",
+    "method" : "PUT"
+  },
+  "response" : {
+    "status" : 400,
+    "body" : "{\"description\":\"inner-broker-provided-error-description\"}",
+    "headers" : {
+      "Cache-Control" : "no-cache, no-store, max-age=0, must-revalidate",
+      "Content-Type" : "application/json;charset=UTF-8",
+      "Date" : "Fri, 23 Mar 2018 12:53:12 GMT",
+      "Expires" : "0",
+      "Pragma" : "no-cache",
+      "Strict-Transport-Security" : "max-age=31536000 ; includeSubDomains",
+      "X-Application-Context" : "application:5000",
+      "X-Content-Type-Options" : "nosniff",
+      "X-Frame-Options" : "DENY",
+      "X-Vcap-Request-Id" : "1f16580b-87ab-48f2-6b26-98c2604a66e4",
+      "X-Xss-Protection" : "1; mode=block"
+    }
+  },
+  "uuid" : "cb2d0641-5ade-4ad6-92a7-981e9a422c83",
+  "persistent" : true,
+  "insertionIndex" : 59
+}

--- a/cf-ops-automation-broker-core/src/main/java/com/orange/oss/cloudfoundry/broker/opsautomation/ondemandbroker/pipeline/OsbProxyImpl.java
+++ b/cf-ops-automation-broker-core/src/main/java/com/orange/oss/cloudfoundry/broker/opsautomation/ondemandbroker/pipeline/OsbProxyImpl.java
@@ -25,6 +25,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
 import org.springframework.util.Base64Utils;
 import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.text.MessageFormat;
 import java.util.HashMap;
@@ -184,58 +185,10 @@ public class OsbProxyImpl implements OsbProxy {
                 .build();
     }
 
-    RuntimeException mapClientException(FeignException exception) {
-        //Once we upgrade to spring5, prefer ResponseStatusException as a programmatic alternative to @ResponseStatus
-        //static response code
-        //see https://github.com/spring-projects/spring-framework/wiki/What%27s-New-in-Spring-Framework-5.x
-        switch (exception.status()) {
-            case 400:
-                return new NestedBroker400StatusException(parseReponseBody(exception).getDescription(), exception);
-            case 409:
-                return new NestedBroker409StatusException(parseReponseBody(exception).getDescription(), exception);
-            case 410:
-                return new NestedBroker410StatusException(parseReponseBody(exception).getDescription(), exception);
-            case 422:
-                return new NestedBroker422StatusException(parseReponseBody(exception).getDescription(), exception);
-            default:
-                return new NestedBroker500StatusException(parseReponseBody(exception).getDescription() + ". Original status: " + exception.status(), exception);
-        }
-    }
-
-    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
-    public static class NestedBroker500StatusException extends RuntimeException {
-        @SuppressWarnings("WeakerAccess")
-        public NestedBroker500StatusException(String message, Throwable cause) {
-            super(message, cause);
-        }
-    }
-    @ResponseStatus(HttpStatus.BAD_REQUEST)
-    public static class NestedBroker400StatusException extends RuntimeException {
-        @SuppressWarnings("WeakerAccess")
-        public NestedBroker400StatusException(String message, Throwable cause) {
-            super(message, cause);
-        }
-    }
-    @ResponseStatus(HttpStatus.CONFLICT)
-    public static class NestedBroker409StatusException extends RuntimeException {
-        @SuppressWarnings("WeakerAccess")
-        public NestedBroker409StatusException(String message, Throwable cause) {
-            super(message, cause);
-        }
-    }
-    @ResponseStatus(HttpStatus.GONE)
-    public static class NestedBroker410StatusException extends RuntimeException {
-        @SuppressWarnings("WeakerAccess")
-        public NestedBroker410StatusException(String message, Throwable cause) {
-            super(message, cause);
-        }
-    }
-    @ResponseStatus(HttpStatus.UNPROCESSABLE_ENTITY)
-    public static class NestedBroker422StatusException extends RuntimeException {
-        @SuppressWarnings("WeakerAccess")
-        public NestedBroker422StatusException(String message, Throwable cause) {
-            super(message, cause);
-        }
+    ResponseStatusException mapClientException(FeignException exception) {
+        //Note: we don't pass the FeignException as cause to not leak confidential internal details such as the url
+        // available in the FeignException
+        return new ResponseStatusException(exception.status(), parseReponseBody(exception).getDescription(), null);
     }
 
 

--- a/cf-ops-automation-broker-core/src/main/java/com/orange/oss/cloudfoundry/broker/opsautomation/ondemandbroker/pipeline/OsbProxyImpl.java
+++ b/cf-ops-automation-broker-core/src/main/java/com/orange/oss/cloudfoundry/broker/opsautomation/ondemandbroker/pipeline/OsbProxyImpl.java
@@ -188,7 +188,9 @@ public class OsbProxyImpl implements OsbProxy {
     ResponseStatusException mapClientException(FeignException exception) {
         //Note: we don't pass the FeignException as cause to not leak confidential internal details such as the url
         // available in the FeignException
-        return new ResponseStatusException(exception.status(), parseReponseBody(exception).getDescription(), null);
+        ErrorMessage errorMessage = parseReponseBody(exception);
+        String description = errorMessage == null ? null: errorMessage.getDescription();
+        return new ResponseStatusException(exception.status(), description, null);
     }
 
 

--- a/cf-ops-automation-broker-core/src/main/java/com/orange/oss/cloudfoundry/broker/opsautomation/ondemandbroker/pipeline/OsbProxyImpl.java
+++ b/cf-ops-automation-broker-core/src/main/java/com/orange/oss/cloudfoundry/broker/opsautomation/ondemandbroker/pipeline/OsbProxyImpl.java
@@ -141,7 +141,7 @@ public class OsbProxyImpl implements OsbProxy {
         try {
             delegateUnbind(mappedRequest, serviceInstanceBindingServiceClient);
         } catch (FeignException e) {
-            logger.error("inner broker bind request rejected:" + e);
+            logger.warn("inner broker bind request rejected:" + e);
             throw mapClientException(e);
         }
 
@@ -172,7 +172,7 @@ public class OsbProxyImpl implements OsbProxy {
 
     CreateServiceInstanceAppBindingResponse mapBindResponse(ResponseEntity<CreateServiceInstanceAppBindingResponse> delegatedResponse, FeignException bindException, Catalog catalog) {
         if (bindException != null) {
-            logger.error("inner broker bind request rejected:" + bindException);
+            logger.warn("inner broker bind request rejected:" + bindException);
             throw mapClientException(bindException);
         }
         CreateServiceInstanceAppBindingResponse delegatedResponseBody = delegatedResponse.getBody();
@@ -193,6 +193,8 @@ public class OsbProxyImpl implements OsbProxy {
                 return new NestedBroker400StatusException(parseReponseBody(exception).getDescription(), exception);
             case 409:
                 return new NestedBroker409StatusException(parseReponseBody(exception).getDescription(), exception);
+            case 410:
+                return new NestedBroker410StatusException(parseReponseBody(exception).getDescription(), exception);
             case 422:
                 return new NestedBroker422StatusException(parseReponseBody(exception).getDescription(), exception);
             default:
@@ -218,6 +220,13 @@ public class OsbProxyImpl implements OsbProxy {
     public static class NestedBroker409StatusException extends RuntimeException {
         @SuppressWarnings("WeakerAccess")
         public NestedBroker409StatusException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+    @ResponseStatus(HttpStatus.GONE)
+    public static class NestedBroker410StatusException extends RuntimeException {
+        @SuppressWarnings("WeakerAccess")
+        public NestedBroker410StatusException(String message, Throwable cause) {
             super(message, cause);
         }
     }

--- a/cf-ops-automation-broker-core/src/main/java/com/orange/oss/ondemandbroker/ProcessorChainServiceHelper.java
+++ b/cf-ops-automation-broker-core/src/main/java/com/orange/oss/ondemandbroker/ProcessorChainServiceHelper.java
@@ -2,16 +2,27 @@ package com.orange.oss.ondemandbroker;
 
 import com.orange.oss.cloudfoundry.broker.opsautomation.ondemandbroker.UserFacingRuntimeException;
 import org.springframework.cloud.servicebroker.exception.ServiceInstanceDoesNotExistException;
+import org.springframework.web.server.ResponseStatusException;
 
 class ProcessorChainServiceHelper {
 
     static RuntimeException processInternalException(RuntimeException exception) {
         if (exception instanceof UserFacingRuntimeException) {
             return exception;
-        } else if (exception.getClass().getPackage().equals(ServiceInstanceDoesNotExistException.class.getPackage())) {
+        } else if (exception instanceof ResponseStatusException) {
+            //flow up spring response status exception mapped by OsbProxy directly as to preserve status code.
+            //Did not find programmatic status code support in sc-osb service broker exception
+            return exception;
+        } else if (isDefinedInServiceBrokerExceptionPackage(exception)) {
+            //flow up sc-osb exceptions directly
             return exception;
         } else {
             return new RuntimeException("Internal error condition. Please contact admin to have him check broker logs"); //filter out potential confidential data
         }
     }
+
+    private static boolean isDefinedInServiceBrokerExceptionPackage(RuntimeException exception) {
+        return exception.getClass().getPackage().equals(ServiceInstanceDoesNotExistException.class.getPackage());
+    }
+
 }

--- a/cf-ops-automation-broker-core/src/main/java/com/orange/oss/ondemandbroker/RawResponseStatusExceptionWebMvcExceptionHandler.java
+++ b/cf-ops-automation-broker-core/src/main/java/com/orange/oss/ondemandbroker/RawResponseStatusExceptionWebMvcExceptionHandler.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2002-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.orange.oss.ondemandbroker;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.cloud.servicebroker.annotation.ServiceBrokerRestController;
+import org.springframework.cloud.servicebroker.controller.ServiceBrokerWebMvcExceptionHandler;
+import org.springframework.cloud.servicebroker.model.error.ErrorMessage;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+/**
+ * By passes {@link ServiceBrokerWebMvcExceptionHandler} to map {@link ResponseStatusException} to the native http
+ * status code, and the reason to the osb `description` field.
+ * @see <a href="https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#service-broker-errors">osb spec section on service broker errors</a>
+ *
+ * This is necessary to directly return nested inner broker response codes to osb caller and avoid swallowing
+ * important messages/status into default 500 errors.
+ *
+ * We expect nested inner broker messages to be user facing and not leak confidential details
+ */
+@ControllerAdvice(annotations = ServiceBrokerRestController.class)
+@ResponseBody
+@Order(Ordered.LOWEST_PRECEDENCE - 11) // ServiceBrokerWebMvcExceptionHandler has a precedence of lowest-10
+public class RawResponseStatusExceptionWebMvcExceptionHandler extends ResponseEntityExceptionHandler {
+
+	private static final Logger LOG = LoggerFactory.getLogger(RawResponseStatusExceptionWebMvcExceptionHandler.class);
+
+	@ExceptionHandler(value = {ResponseStatusException.class})
+	protected ResponseEntity<Object> handleException(
+		RuntimeException ex, WebRequest request) {
+		LOG.info("Mapping ResponseStatusException to its native status code and message: {}", ex.toString());
+		ResponseStatusException responseStatusException = (ResponseStatusException) ex;
+		return handleExceptionInternal(ex, new ErrorMessage(responseStatusException.getReason()),
+			new HttpHeaders(), responseStatusException.getStatus(), request);
+	}
+
+}

--- a/cf-ops-automation-broker-core/src/test/java/com/orange/oss/cloudfoundry/broker/opsautomation/ondemandbroker/pipeline/OsbProxyImplTest.java
+++ b/cf-ops-automation-broker-core/src/test/java/com/orange/oss/cloudfoundry/broker/opsautomation/ondemandbroker/pipeline/OsbProxyImplTest.java
@@ -559,6 +559,25 @@ public class OsbProxyImplTest {
     }
 
     @Test
+    public void maps_gone_bind_request() {
+        //Given
+        Response errorReponse = Response.builder()
+                .status(HttpStatus.GONE.value())
+                .headers(new HashMap<>())
+                .body("{}", Charset.defaultCharset())
+                .request(aFeignRequest)
+                .build();
+        FeignException provisionException = FeignException.errorStatus("ServiceInstanceBindingServiceClient#createServiceInstanceBinding(String,String,String,String,CreateServiceInstanceBindingRequest)", errorReponse);
+
+        //when
+
+        Exception exception = assertThrows(Exception.class,
+            () -> osbProxy.mapBindResponse(null, provisionException, aCatalog()));
+        //check that the associated class is properly annotated for spring to return the corresponding status
+        assertThat(exception.getClass().getAnnotation(ResponseStatus.class).value()).isEqualTo(HttpStatus.GONE);
+    }
+
+    @Test
     public void maps_feign_client_unknown_errors_to_500_errors() {
         //Given
         Response errorReponse = Response.builder()

--- a/docs/6-GONE-osbproxy-response-mapping-issue-435.md
+++ b/docs/6-GONE-osbproxy-response-mapping-issue-435.md
@@ -1,0 +1,19 @@
+
+Pb: GONE response status is always mapped to 500 errors, even when wrapped into our exception mechanism
+* root cause is sc-osb lib mapping unknown exceptions to 500 including spring ResponseStatusException
+
+Pb: the response code and message mapping is using spring4 annotation based mechanism and therefore handling individually each status code
+
+Use of ReResponseStatusException requires integration testing to make sure Spring does not swallow the configured user-facing broker error message
+
+See https://stackoverflow.com/questions/62459836/exception-message-not-included-in-response-when-throwing-responsestatusexception
+
+https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.3-Release-Notes#changes-to-the-default-error-pages-content 
+```
+Changes to the Default Error Page’s Content
+
+The error message and any binding errors are no longer included in the default error page by default. This reduces the risk of leaking information to a client. server.error.include-message and server.error.include-binding-errors can be used to control the inclusion of the message and binding errors respectively. Supported values are always, on-param, and never.
+```
+
+How to test it ?
+* [ ] Add a test case in BoshServiceProvisionningTest with a wiremock binding response returning 400 Bad request status with an associated message

--- a/docs/6-GONE-osbproxy-response-mapping-issue-435.md
+++ b/docs/6-GONE-osbproxy-response-mapping-issue-435.md
@@ -1,22 +1,17 @@
 
 Pb: GONE response status is always mapped to 500 errors, even when wrapped into our exception mechanism
-* root cause is sc-osb lib mapping unknown exceptions to 500 including spring ResponseStatusException. 
-   * Alternative fixes
-     * [ ] map to sc-osb named exceptions: 
-       * pb: would display possibly misleading exception names to coab operators, e.g. 422 would be mapped to ServiceInstanceBindingDoesNotExistException
-       * pb: would display misleading user exception messages to osb client platform users 
-         * [ ] with distinct exception depending on the current operation: provision vs bind ...
-     * [ ] Contribute programmatic error status support in sc-osb
-     * [ ] Override ServiceBrokerWebMvcExceptionHandler with a custom bean with higher precedence 
-* additionally, sc-osb has no direct 410 gone exception, instead different exception is required for different operation, see https://github.com/spring-cloud/spring-cloud-open-service-broker/issues/279 and https://github.com/spring-cloud/spring-cloud-open-service-broker/commit/b7b739da0a276213d4ce444cc026831abc173242
-
-Pb: the response code and message mapping is using spring4 annotation based mechanism and therefore handling individually each status code
-
-Use of ResponseStatusException requires integration testing to make sure Spring does not swallow the configured user-facing broker error message
-
-See https://stackoverflow.com/questions/62459836/exception-message-not-included-in-response-when-throwing-responsestatusexception
-
-https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.3-Release-Notes#changes-to-the-default-error-pages-content 
+* one cause is ourselves wrapping as ServiceBrokerException which gets mapped to 500 errors.
+* second cause is sc-osb missing support for programmatic status code return (only support named exceptions)
+* third cause is sc-osb lib mapping unknown exceptions to 500 including spring5 ResponseStatusException designed for .
+* Alternative fixes
+  * [ ] map to sc-osb named exceptions: 
+    * pb: would display possibly misleading exception names to coab operators, e.g. 422 would be mapped to ServiceInstanceBindingDoesNotExistException
+    * pb: would display misleading user exception messages to osb client platform users 
+      * [ ] with distinct exception depending on the current operation: provision vs bind ...
+  * [ ] Contribute programmatic error status support in sc-osb
+  * [x] Override ServiceBrokerWebMvcExceptionHandler with a custom bean with higher precedence
+     * See https://www.baeldung.com/exception-handling-for-rest-with-spring#controlleradvice
+     * This also addresses default spring leak prevention mechanism. See https://stackoverflow.com/questions/62459836/exception-message-not-included-in-response-when-throwing-responsestatusexception and https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.3-Release-Notes#changes-to-the-default-error-pages-content 
 ```
 Changes to the Default Error Page’s Content
 
@@ -24,4 +19,4 @@ The error message and any binding errors are no longer included in the default e
 ```
 
 How to test it ?
-* [ ] Add a test case in BoshServiceProvisionningTest with a wiremock binding response returning 400 Bad request status with an associated message
+* [x] Add a test case in BoshServiceProvisionningTest with a wiremock binding response returning 400 Bad request status with an associated message

--- a/docs/6-GONE-osbproxy-response-mapping-issue-435.md
+++ b/docs/6-GONE-osbproxy-response-mapping-issue-435.md
@@ -1,10 +1,18 @@
 
 Pb: GONE response status is always mapped to 500 errors, even when wrapped into our exception mechanism
-* root cause is sc-osb lib mapping unknown exceptions to 500 including spring ResponseStatusException
+* root cause is sc-osb lib mapping unknown exceptions to 500 including spring ResponseStatusException. 
+   * Alternative fixes
+     * [ ] map to sc-osb named exceptions: 
+       * pb: would display possibly misleading exception names to coab operators, e.g. 422 would be mapped to ServiceInstanceBindingDoesNotExistException
+       * pb: would display misleading user exception messages to osb client platform users 
+         * [ ] with distinct exception depending on the current operation: provision vs bind ...
+     * [ ] Contribute programmatic error status support in sc-osb
+     * [ ] Override ServiceBrokerWebMvcExceptionHandler with a custom bean with higher precedence 
+* additionally, sc-osb has no direct 410 gone exception, instead different exception is required for different operation, see https://github.com/spring-cloud/spring-cloud-open-service-broker/issues/279 and https://github.com/spring-cloud/spring-cloud-open-service-broker/commit/b7b739da0a276213d4ce444cc026831abc173242
 
 Pb: the response code and message mapping is using spring4 annotation based mechanism and therefore handling individually each status code
 
-Use of ReResponseStatusException requires integration testing to make sure Spring does not swallow the configured user-facing broker error message
+Use of ResponseStatusException requires integration testing to make sure Spring does not swallow the configured user-facing broker error message
 
 See https://stackoverflow.com/questions/62459836/exception-message-not-included-in-response-when-throwing-responsestatusexception
 


### PR DESCRIPTION
410 is in the specs https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#unbinding and should not converted to 500

Fixes #435

And now maps all inner broker error codes to their original code + message.