### PR TITLE
Springboot bump 2.5.1

### DIFF
--- a/cf-ops-automation-bosh-broker/pom.xml
+++ b/cf-ops-automation-bosh-broker/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.4.2</version>
+        <version>2.5.1</version>
         <relativePath /> <!-- lookup parent from repository -->
     </parent>
 

--- a/cf-ops-automation-broker-core/pom.xml
+++ b/cf-ops-automation-broker-core/pom.xml
@@ -21,7 +21,7 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>1.8</java.version>
 		<orangeSpringCloudServiceBrokerVersion>a13e8c6fb811f0c8bd4c4916edff6405db3cdfd0</orangeSpringCloudServiceBrokerVersion>
-		<upstreamSpringCloudServiceBrokerVersion>3.3.1</upstreamSpringCloudServiceBrokerVersion>
+		<upstreamSpringCloudServiceBrokerVersion>3.4.0</upstreamSpringCloudServiceBrokerVersion>
 	</properties>
 
 	<dependencies>

--- a/cf-ops-automation-terraform-broker/pom.xml
+++ b/cf-ops-automation-terraform-broker/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.4.2</version>
+        <version>2.5.1</version>
         <relativePath /> <!-- lookup parent from repository -->
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.4.2</version>
+        <version>2.5.1</version>
         <relativePath /> <!-- lookup parent from repository -->
     </parent>
 


### PR DESCRIPTION
includes and closes #459 : Bump spring-cloud-starter-open-service-broker from 3.3.1 to 3.4.0
includes and closes #395: Bump spring-boot-starter-parent from 2.4.2 to 2.5.1