### PR TITLE
Bump springboot 26x

### DIFF
--- a/cf-ops-automation-bosh-broker/pom.xml
+++ b/cf-ops-automation-bosh-broker/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.5.8</version>
+        <version>2.6.2</version>
         <relativePath /> <!-- lookup parent from repository -->
     </parent>
 

--- a/cf-ops-automation-broker-core/pom.xml
+++ b/cf-ops-automation-broker-core/pom.xml
@@ -181,7 +181,7 @@
 		<dependency>
 			<groupId>io.github.openfeign</groupId>
 			<artifactId>feign-okhttp</artifactId>
-			<version>11.8</version>
+			<version>11.6</version>
 		</dependency>
 
 		<dependency>

--- a/cf-ops-automation-broker-core/pom.xml
+++ b/cf-ops-automation-broker-core/pom.xml
@@ -181,7 +181,7 @@
 		<dependency>
 			<groupId>io.github.openfeign</groupId>
 			<artifactId>feign-okhttp</artifactId>
-			<version>11.6</version>
+			<version>11.8</version>
 		</dependency>
 
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-dependencies</artifactId>
-                <version>2020.0.5</version>
+                <version>2021.0.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.5.8</version>
+        <version>2.6.2</version>
         <relativePath /> <!-- lookup parent from repository -->
     </parent>
 


### PR DESCRIPTION
springboot bump to 2.6.1 along with spring cloud 2021.0.0

Associated release notes 
https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.6-Release-Notes and https://github.com/spring-cloud/spring-cloud-release/wiki/Spring-Cloud-2021.0-Release-Notes


still fails with `feign-okhttp bump from 11.6 to 11.8`

embeds and closes:
closes #462 
closes #455 